### PR TITLE
perf: Phase A — dead-code cleanup + 32-byte SWAR quad-pump in skip_to…

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -72,8 +72,8 @@ endforeach()
 
 # Optimization and PGO
 if(NOT CMAKE_BUILD_TYPE MATCHES "Debug")
-    add_compile_options(-O3 -march=native -flto)
-    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+    add_compile_options(-O3 -flto -fuse-ld=lld)
+    add_link_options(-fuse-ld=lld -flto)
 endif()
 
 set(PGO_MODE "" CACHE STRING "PGO mode: GENERATE or USE")


### PR DESCRIPTION
…_action()

Pre-Phase-A cleanup (6944 → 5689 lines):
- Fix BEAST_LIKELY/BEAST_UNLIKELY: were no-ops, now __builtin_expect
- Fix BEAST_HAS_NEON: remove double-definition in document_view section
- Remove TapeNode::aux field (12 bytes, down from 16); update static_assert
- Remove dead structs: StructuralIndex, CPUFeatures
- Remove ~1100 lines of dead functions: escape_string, fill_bitmap_and_find_splits, parse_8digits_neon, parse_digits_simd, parse_uint64_fast, validate_utf8, scan_string_detect, count_escapes_neon, scan_copy_string, parse_decimal, lookup::is_structural, detail::has_quote/has_escape, lazy::neon_find_next, legacy find_array_boundaries stub, GhostType::SimpleDecimal
- Remove duplicate #includes, filesystem include, unused thread comment

Phase A2 — 32-byte SWAR quad-pump in skip_to_action() (#else / x86-64 path):
- Process 32 bytes per iteration (4x load64) with single OR-merge branch
- Falls back to existing 8-byte loop for tail bytes
- No impact on ARM64 (NEON path is taken instead)

Phase A1 (bitmap pre-scan) was implemented and reverted: fill_bitmap()'s extra O(n) full-file pass costs more than bitmap_next_action() CTZ lookups save on the 616KB twitter.json file (exceeds L2 cache). Short 1-3 byte WS gaps are already handled optimally by skip_to_action()'s fast-path if (c > 0x20) check.

Also: benchmarks/CMakeLists.txt — use lld linker (gold not available on Termux); OPTIMIZATION_PLAN.md — record Phase A outcomes, advance roadmap to Phase B1.