### PR TITLE
ci: disable parallel builds to prevent OOM segfaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
 
     - name: Build (Native)
       if: runner.os != 'Linux' || matrix.arch == 'x86_64'
-      run: cmake --build build --config ${{ matrix.build_type }} -j4
+      run: cmake --build build --config ${{ matrix.build_type }} -j1
 
     - name: Test (Native)
       if: runner.os != 'Linux' || matrix.arch == 'x86_64'


### PR DESCRIPTION
Compiler segfaulted during test_trailing_commas.cpp.o on ubuntu gcc debug due to insufficient memory in CI runners. Changed -j4 to -j1 for native builds to match the existing -j1 used in cross-compilation (run-on-arch).

https://claude.ai/code/session_019B5XhdbuvZkeTY7owCuEMw