### PR TITLE
Harden qbuem-json (wave 2): 12 type-safety / memory-safety / DoS / type-confusion fixes + zero-copy UAF guards + decoded() API

### DIFF
--- a/include/qbuem_json/qbuem_json.hpp
+++ b/include/qbuem_json/qbuem_json.hpp
@@ -7191,6 +7191,11 @@ inline Value parse_partial(DocumentView &handle, std::string_view json, size_t* 
   if (consumed) *consumed = p.get_p() - json.data();
   return Value(doc, 0);
 }
+// Zero-copy: the returned Value views into `json`.  Reject rvalue std::string
+// at compile time so a temporary buffer cannot become a use-after-free (mirrors
+// the Document& overloads).  Keep an lvalue alive, or use read<T>()/fuse<T>().
+Value parse_partial(DocumentView &, const ::std::string &&,
+                    size_t * = nullptr) = delete;
 
 inline Value parse_reuse(DocumentView &handle, std::string_view json) {
   DocumentState *doc = handle.state();
@@ -7241,6 +7246,10 @@ inline Value parse_reuse(DocumentView &handle, std::string_view json) {
 #endif
   return Value(doc, 0);
 }
+// Zero-copy: the returned Value views into `json`.  Reject rvalue std::string at
+// compile time so a temporary buffer cannot become a use-after-free (mirrors the
+// Document& overload).  Keep an lvalue alive, or use read<T>()/fuse<T>().
+Value parse_reuse(DocumentView &, const ::std::string &&) = delete;
 
 // ── Value::merge_patch() out-of-line (needs parse_reuse) ────────────────────
 inline void Value::merge_patch(std::string_view patch_json) {
@@ -7932,6 +7941,10 @@ inline Value parse_strict(DocumentView &doc, ::std::string_view json) {
   rfc8259::validate(json);
   return qbuem::json::parse_reuse(doc, json);
 }
+// Zero-copy: the returned Value views into `json`.  Reject rvalue std::string at
+// compile time so a temporary buffer cannot become a use-after-free (mirrors the
+// Document& overload).  Keep an lvalue alive, or use read<T>()/fuse<T>().
+Value parse_strict(DocumentView &, const ::std::string &&) = delete;
 
 } // namespace rfc8259
 
@@ -8766,6 +8779,17 @@ namespace rfc8259 = json::rfc8259;
 // will not compile.  Pass an lvalue you keep alive (or a string literal), e.g.
 //   std::string text = get_config_json();  auto v = qbuem::parse(doc, text);
 // If you need an owning value, use read<T>()/fuse<T>() (they copy into T).
+//
+// Thread-safety / aliasing:
+//   • A Document owns mutable parse state; one Document is single-threaded.  Do
+//     NOT parse into, mutate, or destroy the same Document from two threads.
+//   • Every Value/SafeValue from a Document ALIASES that Document's tape and the
+//     input buffer — they are lightweight handles, not copies.  After a read-only
+//     parse you MAY hand those handles to multiple threads that only READ
+//     concurrently (no data race: the tape is immutable once parsed).  As soon as
+//     ANY thread mutates (insert/erase/operator[]=/merge_patch) or re-parses the
+//     Document, all concurrent access must stop — mutation rewrites shared state.
+//   • Distinct Documents share nothing and are fully independent across threads.
 inline Value parse(Document &doc, ::std::string_view json) {
   return json::parse_reuse(doc, json);
 }

--- a/include/qbuem_json/qbuem_json.hpp
+++ b/include/qbuem_json/qbuem_json.hpp
@@ -4461,7 +4461,11 @@ private:
     std::string out;
     out.reserve(doc_->source.size() + doc_->additions_.size() * 64 + 64);
 
-    // Stack-based separator state (max 64 nesting levels)
+    // Per-depth separator state.  Sized to the tape Parser's maximum nesting
+    // depth (1088): the tape can never be deeper, since parse() rejects past
+    // that.  Previously a fixed `Frame stk[64]`, which a document nested deeper
+    // than 64 overran (stack-buffer-overflow) once a mutation routed dump()
+    // here.  Heap-backed so the deep case adds no stack pressure.
     struct Frame {
       bool is_obj;
       bool has_prev;
@@ -4469,7 +4473,7 @@ private:
       uint32_t start_idx;
       size_t arr_idx;
     };
-    Frame stk[64];
+    std::vector<Frame> stk(1088);
     int top = -1;
 
     uint32_t i = start_c;
@@ -4711,6 +4715,14 @@ private:
     if (!doc_) {
       out += "null";
       return idx_ + 1;
+    }
+    // Bound recursion: each level adds a C++ stack frame, and the parser permits
+    // nesting up to ~1088, which can exhaust a small (worker/embedded) thread
+    // stack.  Beyond a generous cap, fall back to the iterative compact dump of
+    // this subtree (still valid JSON, just not indented past this point).
+    if (QBUEM_UNLIKELY(depth > 500)) {
+      out += dump();
+      return skip_value_(idx_);
     }
     const TapeNodeType root_type = doc_->tape[idx_].type();
 
@@ -5377,7 +5389,11 @@ class Parser {
     //
     // SWAR-8 pre-gate: twitter.json has 2-8 WS bytes between tokens; absorb
     // them here before paying any 512-bit register setup cost (    // lesson).
-    {
+    // Guard `p_ + 8 <= end_`: load64() reads 8 bytes, and the input is an
+    // unpadded caller-supplied string_view, so without this an input ending
+    // within 7 bytes of a page boundary reads out of bounds.  When too close
+    // to the end, fall through to the scalar tail below.
+    if (QBUEM_LIKELY(p_ + 8 <= end_)) {
       uint64_t am = swar_action_mask(load64(p_));
       if (QBUEM_LIKELY(am != 0)) {
         p_ += QBUEM_CTZ(am) >> 3;
@@ -7063,9 +7079,15 @@ public:
 
 // Public API
 
+// Tape node offsets are 32-bit, so the source must fit in a uint32_t index
+// space.  Inputs >= 4 GiB would wrap the offset and produce wrong/out-of-bounds
+// slices; reject them up front.
+inline constexpr size_t kMaxInputSize = 0xFFFFFFFFu;
+
 inline Value parse_partial(DocumentView &handle, std::string_view json, size_t* consumed = nullptr) {
   DocumentState *doc = handle.state();
   if (!doc) return {};
+  if (QBUEM_UNLIKELY(json.size() > kMaxInputSize)) return {};
   doc->source = json;
   doc->mutations_.clear(); doc->deleted_.clear(); doc->additions_.clear(); doc->array_insertions_.clear();
   const size_t needed = json.size() + 64;
@@ -7080,6 +7102,8 @@ inline Value parse_reuse(DocumentView &handle, std::string_view json) {
   DocumentState *doc = handle.state();
   if (!doc)
     return {};
+  if (QBUEM_UNLIKELY(json.size() > kMaxInputSize))
+    throw std::runtime_error("qbuem: input exceeds 4 GiB (32-bit offset limit)");
   doc->source = json;
   // Clear mutation / deletion / addition overlays from any prior parse.
   // These maps reference tape indices that are invalidated when the tape is
@@ -7502,16 +7526,27 @@ DocumentState::get_synthetic(const ::std::string &json_str) const {
   if (it != synthetic_docs_.end())
     return it->second.get();
 
-  DocumentView synth_handle(json_str);
+  // Reserve the cache slot first so the map owns a STABLE copy of the key, and
+  // point the synthetic document's `source` view at that stable key — NOT at
+  // the `json_str` argument.  The argument is typically a reference to a string
+  // stored in additions_/array_insertions_, which erase_from_additions_/merge()
+  // can free; since synthetic_docs_ is never invalidated, a source view into
+  // the freed argument would dangle (use-after-free).  unordered_map key
+  // references are stable across other insert/erase operations.
+  auto [slot, inserted] = synthetic_docs_.try_emplace(json_str);
+  const std::string &stable_key = slot->first;
+
+  DocumentView synth_handle(std::string_view{stable_key});
   // parse_reuse throws on unparseable input.  get_synthetic is reached from
   // noexcept accessors (operator[], dump helpers), so an escape here would
   // call std::terminate.  An inserted value can be unparseable when its
   // serialized form exceeds the 64KB token limit (e.g. a short string whose
-  // escaped \uXXXX expansion crosses 65535 bytes) — return nullptr so callers
-  // produce an invalid Value instead of crashing.
+  // escaped \uXXXX expansion crosses 65535 bytes) — erase the reserved slot
+  // and return nullptr so callers produce an invalid Value instead of crashing.
   try {
-    parse_reuse(synth_handle, json_str);
+    parse_reuse(synth_handle, std::string_view{stable_key});
   } catch (...) {
+    synthetic_docs_.erase(slot);
     return nullptr;
   }
 
@@ -7523,7 +7558,7 @@ DocumentState::get_synthetic(const ::std::string &json_str) const {
   // Increment ref for the shared_ptr so it doesn't delete when handle goes away
   s->ref();
 
-  synthetic_docs_[json_str] = std::move(shared);
+  slot->second = std::move(shared);
   return s;
 }
 
@@ -8533,7 +8568,13 @@ inline void to_json_field(Value &obj, const char *key, const T &val) {
   ::qbuem::json::detail::to_json_field(v, #f, obj.f);
 #define QBUEM_JSON_DETAIL_PULSE(f)                                             \
   case ::qbuem::json::detail::fast_key_hash_ce(#f):                            \
-    ::qbuem::json::detail::from_json_direct(p, end, obj.f);                    \
+    /* Verify the actual key bytes — the hash is collision-prone, so without  \
+       this an untrusted key could be routed into the wrong field (spoofing / \
+       type confusion).  One short compare per object key. */                 \
+    if (_key == ::std::string_view(#f, sizeof(#f) - 1))                        \
+      ::qbuem::json::detail::from_json_direct(p, end, obj.f);                  \
+    else                                                                       \
+      ::qbuem::json::detail::skip_direct(p, end);                              \
     break;
 
 // QBUEM_JSON_DETAIL_APPEND_FW — FastWriter path: zero std::string overhead
@@ -8547,8 +8588,8 @@ inline void to_json_field(Value &obj, const char *key, const T &val) {
 
 #define QBUEM_JSON_FIELDS(Type, ...)                                           \
   /* Fast dispatch on pre-computed key hash — primary hot path */              \
-  inline void nexus_pulse_h(uint64_t _h, const char *&p,                      \
-                            const char *end, Type &obj) {                      \
+  inline void nexus_pulse_h(uint64_t _h, ::std::string_view _key,             \
+                            const char *&p, const char *end, Type &obj) {      \
     switch (_h) {                                                              \
       QBUEM_FOR_EACH(QBUEM_JSON_DETAIL_PULSE, __VA_ARGS__)                     \
     default:                                                                   \
@@ -8559,7 +8600,8 @@ inline void to_json_field(Value &obj, const char *key, const T &val) {
   /* Backward-compat wrapper: hashes the key then dispatches via nexus_pulse_h */\
   inline void nexus_pulse(::std::string_view key, const char *&p,              \
                           const char *end, Type &obj) {                        \
-    nexus_pulse_h(::qbuem::json::detail::fast_key_hash(key), p, end, obj);    \
+    nexus_pulse_h(::qbuem::json::detail::fast_key_hash(key), key, p, end,     \
+                  obj);                                                        \
   }                                                                            \
   inline void from_qbuem_json(const ::qbuem::json::Value &v, Type &obj) {      \
     QBUEM_FOR_EACH(QBUEM_JSON_DETAIL_READ, __VA_ARGS__)                        \
@@ -8620,18 +8662,40 @@ using SafeValue = json::SafeValue;
 
 namespace rfc8259 = json::rfc8259;
 
+// ── parse* lifetime contract ────────────────────────────────────────────────
+// parse/parse_reuse/parse_strict are ZERO-COPY: the returned Value (and the
+// Document) holds a non-owning view of `json`.  The input buffer MUST outlive
+// the Document and every Value derived from it — nothing is copied.  To make
+// the most common misuse a COMPILE error instead of a silent use-after-free,
+// the rvalue-`std::string` overloads are deleted, so e.g.
+//   auto v = qbuem::parse(doc, get_config_json());   // ERROR: deleted overload
+// will not compile.  Pass an lvalue you keep alive (or a string literal), e.g.
+//   std::string text = get_config_json();  auto v = qbuem::parse(doc, text);
+// If you need an owning value, use read<T>()/fuse<T>() (they copy into T).
 inline Value parse(Document &doc, ::std::string_view json) {
   return json::parse_reuse(doc, json);
 }
+inline Value parse(Document &doc, const char *json) {
+  return json::parse_reuse(doc, ::std::string_view(json));
+}
+Value parse(Document &, const ::std::string &&) = delete;
 
 inline Value parse_reuse(Document &doc, ::std::string_view json) {
   return json::parse_reuse(doc, json);
 }
+inline Value parse_reuse(Document &doc, const char *json) {
+  return json::parse_reuse(doc, ::std::string_view(json));
+}
+Value parse_reuse(Document &, const ::std::string &&) = delete;
 
 inline Value parse_strict(Document &doc, ::std::string_view json) {
   json::rfc8259::validate(json);
   return json::parse_reuse(doc, json);
 }
+inline Value parse_strict(Document &doc, const char *json) {
+  return parse_strict(doc, ::std::string_view(json));
+}
+Value parse_strict(Document &, const ::std::string &&) = delete;
 
 namespace json::detail {
 
@@ -8645,6 +8709,11 @@ struct NexusScanner {
   const char *p;
   const char *end;
   const char *begin = nullptr; // optional: set by fuse()/fuse_strict() for offset reporting
+  // Raw bytes of the most recent key scanned by read_key_h(); used to verify
+  // the hash-dispatch match against the actual field name (the hash alone is
+  // collision-prone, which would let an attacker route an untrusted key into
+  // the wrong struct field — field spoofing / type confusion).
+  std::string_view last_key_{};
 
   QBUEM_INLINE void ws() noexcept { detail::ws(p, end); }
 
@@ -8725,6 +8794,7 @@ struct NexusScanner {
           if (p < end && *p == ':') [[likely]] ++p;
           // Hash = raw bytes [0..bp-1], zero-padded — identical to fast_key_hash_ce
           const uint64_t mask = bp ? ((uint64_t(1) << (bp * 8)) - 1) : uint64_t(0);
+          last_key_ = std::string_view(start, static_cast<size_t>(bp));
           return w & mask;
         }
       }
@@ -8773,6 +8843,7 @@ struct NexusScanner {
     if (p < end) ++p;
     if (p < end && (unsigned char)*p <= 32) [[unlikely]] ws();
     if (p < end && *p == ':') [[likely]] ++p;
+    last_key_ = std::string_view{start, n};
     return detail::fast_key_hash(std::string_view{start, n});
   }
 
@@ -8807,6 +8878,27 @@ inline bool &nexus_strict_mode() noexcept {
   return flag;
 #endif
 }
+
+// Nexus recursion-depth bound.  The typed from_json_direct path recurses through
+// nested structs / Optional / Map / Tuple / Seq with no cap; a recursive-typed
+// schema (e.g. a tree node) fed deeply-nested untrusted JSON would exhaust the
+// native stack (SIGSEGV).  skip_direct is already bounded via the Validator;
+// this RAII guard bounds the typed path to the same depth.  Only the recursive
+// branches construct it, so scalar fields pay nothing.
+inline int &nexus_depth() noexcept {
+  thread_local int d = 0;
+  return d;
+}
+struct NexusDepthGuard {
+  static constexpr int kMax = 1024;
+  NexusDepthGuard() {
+    if (++nexus_depth() > kMax) {
+      --nexus_depth();
+      throw std::runtime_error("Nexus: input nesting too deep");
+    }
+  }
+  ~NexusDepthGuard() { --nexus_depth(); }
+};
 
 // peek_json_type: returns a human-readable label for the JSON token at *p.
 // Used in Nexus error messages so callers see "expected number, got string"
@@ -8851,6 +8943,7 @@ QBUEM_COLD inline const char *peek_json_type(const char *p, const char *end) noe
 template <typename T> void from_json_direct(const char *&p, const char *end, T &out) {
   if (p >= end) return;
   if constexpr (HasNexusPulse<T>) {
+    NexusDepthGuard _g; // bound recursion (nested struct)
     NexusScanner scanner{p, end};
     scanner.fill(out);
     p = scanner.p;
@@ -8873,6 +8966,15 @@ template <typename T> void from_json_direct(const char *&p, const char *end, T &
     }
     const char *start = p;
     while (p < end && ((*p >= '0' && *p <= '9') || *p == '-' || *p == '.' || *p == 'e' || *p == 'E' || *p == '+')) ++p;
+    if (p == start) {
+      // The value is not a number (type mismatch).  Strict mode already threw
+      // above; in relaxed mode the charset loop matched nothing, so p did not
+      // advance — consume the actual token via skip_direct so the cursor stays
+      // in sync.  Without this the value's bytes are mis-read as the next key
+      // and the rest of the object is silently dropped.
+      skip_direct(p, end);
+      return;
+    }
     if constexpr (std::is_floating_point_v<T>) {
       out = static_cast<T>(json::detail::qj_nc::parse_f64(start, p));
     } else {
@@ -8882,6 +8984,7 @@ template <typename T> void from_json_direct(const char *&p, const char *end, T &
       }
     }
   } else if constexpr (JsonDetailOptional<T>) {
+    NexusDepthGuard _g; // bound recursion
     detail::ws(p, end);
     if (p + 4 <= end && !std::memcmp(p, "null", 4)) {
       out = std::nullopt;
@@ -8966,6 +9069,7 @@ template <typename T> void from_json_direct(const char *&p, const char *end, T &
       else skip_direct(p, end);
     }
   } else if constexpr (JsonDetailMap<T>) {
+    NexusDepthGuard _g; // bound recursion
     out.clear();
     detail::ws(p, end);
     if (p < end && *p == '{') {
@@ -8998,6 +9102,7 @@ template <typename T> void from_json_direct(const char *&p, const char *end, T &
       else skip_direct(p, end);
     }
   } else if constexpr (JsonDetailTuple<T>) {
+    NexusDepthGuard _g; // bound recursion
     detail::ws(p, end);
     if (p < end && *p == '[') {
       ++p;
@@ -9015,6 +9120,7 @@ template <typename T> void from_json_direct(const char *&p, const char *end, T &
       else skip_direct(p, end);
     }
   } else if constexpr (JsonDetailSeq<T>) {
+    NexusDepthGuard _g; // bound recursion
     out.clear();
     while (p < end && (unsigned char)*p <= 32) ++p;
     if (p < end && *p == '[') {
@@ -9056,7 +9162,7 @@ template <typename T> inline void NexusScanner::fill(T &obj) {
     if constexpr (HasNexusPulseH<T>) {
       // Fast path: hash computed during key scan — zero extra traversal
       const uint64_t h = read_key_h();
-      nexus_pulse_h(h, p, end, obj);
+      nexus_pulse_h(h, last_key_, p, end, obj);
     } else {
       nexus_pulse(read_key(), p, end, obj);
     }

--- a/include/qbuem_json/qbuem_json.hpp
+++ b/include/qbuem_json/qbuem_json.hpp
@@ -83,6 +83,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <functional>
+#include <limits>
 #include <list>
 #include <map>
 #include <memory>
@@ -2213,6 +2214,40 @@ inline double parse_f64(const char *orig, const char *end) noexcept {
 }
 
 } // namespace qj_nc
+
+// Parse decimal text [beg,end) into integral type T with FULL-WIDTH range
+// support and range checking.  Unsigned T is parsed via uint64_t so the entire
+// unsigned range is readable (the old int64-only path could not read values
+// above INT64_MAX, e.g. UINT64_MAX), and any value outside T's range throws
+// instead of silently wrapping (the old static_cast<T> turned as<uint8_t>(256)
+// into 0).  This is the safe, production-grade conversion contract.
+template <typename T>
+inline T to_integral_checked(const char *beg, const char *end) {
+  if constexpr (std::is_unsigned_v<T>) {
+    uint64_t v = 0;
+    auto [ptr, ec] = std::from_chars(beg, end, v);
+    if (ec != std::errc{})
+      throw std::runtime_error(
+          "qbuem::Value::as<integral>: negative, malformed, or out-of-range "
+          "value for an unsigned target type");
+    if (v > static_cast<uint64_t>(std::numeric_limits<T>::max()))
+      throw std::runtime_error(
+          "qbuem::Value::as<integral>: value exceeds target type maximum");
+    return static_cast<T>(v);
+  } else {
+    int64_t v = 0;
+    auto [ptr, ec] = std::from_chars(beg, end, v);
+    if (ec != std::errc{})
+      throw std::runtime_error(
+          "qbuem::Value::as<integral>: malformed or out-of-range value");
+    if (v < static_cast<int64_t>(std::numeric_limits<T>::min()) ||
+        v > static_cast<int64_t>(std::numeric_limits<T>::max()))
+      throw std::runtime_error(
+          "qbuem::Value::as<integral>: value exceeds target type range");
+    return static_cast<T>(v);
+  }
+}
+
 } // namespace detail (qj_nc)
 
 /// owning `DocumentView` and a 32-bit tape index. It provides zero-copy,
@@ -2369,7 +2404,11 @@ public:
     if (!doc_)
       return;
     char buf[24];
-    char *ptr = detail::qj_nc::to_chars(buf, static_cast<int64_t>(val));
+    // Dispatch on signedness so unsigned values above INT64_MAX serialize
+    // correctly (static_cast<int64_t>(UINT64_MAX) would emit "-1").
+    char *ptr = std::is_unsigned_v<T>
+                    ? detail::qj_nc::to_chars(buf, static_cast<uint64_t>(val))
+                    : detail::qj_nc::to_chars(buf, static_cast<int64_t>(val));
     doc_->mutations_[idx_] = {TapeNodeType::Integer, std::string(buf, ptr)};
     doc_->last_dump_size_ = 0;
   }
@@ -2722,9 +2761,8 @@ public:
           if (m.type != TapeNodeType::Integer)
             throw std::runtime_error(
                 "qbuem::Value::as<integral>: not an integer");
-          int64_t val = 0;
-          std::from_chars(m.data.data(), m.data.data() + m.data.size(), val);
-          return static_cast<T>(val);
+          return detail::to_integral_checked<T>(
+              m.data.data(), m.data.data() + m.data.size());
         } else if constexpr (std::is_floating_point_v<T>) {
           if (m.type != TapeNodeType::Double && m.type != TapeNodeType::Integer)
             throw std::runtime_error("qbuem::Value::as<float>: not a number");
@@ -2758,13 +2796,9 @@ public:
       if (t != TapeNodeType::Integer && t != TapeNodeType::NumberRaw)
         throw std::runtime_error("qbuem::Value::as<integral>: not an integer");
       const TapeNode &nd = doc_->tape[idx_];
-      int64_t val = 0;
       const char *beg = doc_->source.data() + nd.offset;
       const char *end = beg + nd.length();
-      auto [ptr, ec] = std::from_chars(beg, end, val);
-      if (ec != std::errc{})
-        throw std::runtime_error("qbuem::Value::as<integral>: parse error");
-      return static_cast<T>(val);
+      return detail::to_integral_checked<T>(beg, end);
     } else if constexpr (std::is_floating_point_v<T>) {
       const auto t = doc_->tape[idx_].type();
       if (t != TapeNodeType::Double && t != TapeNodeType::NumberRaw &&
@@ -4213,7 +4247,11 @@ private:
   static std::string scalar_to_json_(bool b) { return b ? "true" : "false"; }
   template <JsonInteger T> static std::string scalar_to_json_(T v) {
     char buf[24];
-    char *p = detail::qj_nc::to_chars(buf, static_cast<int64_t>(v));
+    // Dispatch on signedness so unsigned values above INT64_MAX serialize
+    // correctly (static_cast<int64_t>(UINT64_MAX) would emit "-1").
+    char *p = std::is_unsigned_v<T>
+                  ? detail::qj_nc::to_chars(buf, static_cast<uint64_t>(v))
+                  : detail::qj_nc::to_chars(buf, static_cast<int64_t>(v));
     return std::string(buf, p);
   }
   template <JsonFloat T> static std::string scalar_to_json_(T v) {

--- a/include/qbuem_json/qbuem_json.hpp
+++ b/include/qbuem_json/qbuem_json.hpp
@@ -2248,6 +2248,85 @@ inline T to_integral_checked(const char *beg, const char *end) {
   }
 }
 
+// Decode a JSON string body (the raw bytes between the quotes) into its logical
+// value: processes \" \\ \/ \b \f \n \r \t and \uXXXX (with surrogate pairs ->
+// UTF-8).  Malformed/incomplete escapes are passed through literally (the input
+// may come from the relaxed parser).  Used by Value::decoded().
+inline std::string json_unescape(std::string_view s) {
+  std::string out;
+  out.reserve(s.size());
+  const size_t n = s.size();
+  auto hex4 = [&](size_t pos) -> int {
+    int v = 0;
+    for (int k = 0; k < 4; ++k) {
+      char c = s[pos + k];
+      int d;
+      if (c >= '0' && c <= '9') d = c - '0';
+      else if (c >= 'a' && c <= 'f') d = c - 'a' + 10;
+      else if (c >= 'A' && c <= 'F') d = c - 'A' + 10;
+      else return -1;
+      v = (v << 4) | d;
+    }
+    return v;
+  };
+  auto put_utf8 = [&](unsigned cp) {
+    if (cp <= 0x7F) {
+      out += static_cast<char>(cp);
+    } else if (cp <= 0x7FF) {
+      out += static_cast<char>(0xC0 | (cp >> 6));
+      out += static_cast<char>(0x80 | (cp & 0x3F));
+    } else if (cp <= 0xFFFF) {
+      out += static_cast<char>(0xE0 | (cp >> 12));
+      out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+      out += static_cast<char>(0x80 | (cp & 0x3F));
+    } else {
+      out += static_cast<char>(0xF0 | (cp >> 18));
+      out += static_cast<char>(0x80 | ((cp >> 12) & 0x3F));
+      out += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+      out += static_cast<char>(0x80 | (cp & 0x3F));
+    }
+  };
+  size_t i = 0;
+  while (i < n) {
+    char c = s[i];
+    if (c != '\\') { out += c; ++i; continue; }
+    if (i + 1 >= n) { out += c; ++i; break; } // trailing backslash
+    switch (s[i + 1]) {
+      case '"':  out += '"';  i += 2; break;
+      case '\\': out += '\\'; i += 2; break;
+      case '/':  out += '/';  i += 2; break;
+      case 'b':  out += '\b'; i += 2; break;
+      case 'f':  out += '\f'; i += 2; break;
+      case 'n':  out += '\n'; i += 2; break;
+      case 'r':  out += '\r'; i += 2; break;
+      case 't':  out += '\t'; i += 2; break;
+      case 'u': {
+        if (i + 6 > n) { out += c; ++i; break; } // incomplete
+        int cp = hex4(i + 2);
+        if (cp < 0) { out += c; ++i; break; }    // bad hex
+        i += 6;
+        if (cp >= 0xD800 && cp <= 0xDBFF) {       // high surrogate
+          if (i + 6 <= n && s[i] == '\\' && s[i + 1] == 'u') {
+            int lo = hex4(i + 2);
+            if (lo >= 0xDC00 && lo <= 0xDFFF) {
+              put_utf8(0x10000u + ((static_cast<unsigned>(cp) - 0xD800u) << 10) +
+                       (static_cast<unsigned>(lo) - 0xDC00u));
+              i += 6;
+              break;
+            }
+          }
+          put_utf8(static_cast<unsigned>(cp)); // lone high surrogate
+        } else {
+          put_utf8(static_cast<unsigned>(cp)); // BMP or lone low surrogate
+        }
+        break;
+      }
+      default: out += c; ++i; break; // unknown escape: keep literal
+    }
+  }
+  return out;
+}
+
 } // namespace detail (qj_nc)
 
 /// owning `DocumentView` and a 32-bit tape index. It provides zero-copy,
@@ -2810,15 +2889,30 @@ public:
       double val = detail::qj_nc::parse_f64(beg, end);
       return static_cast<T>(val);
     } else if constexpr (std::is_same_v<T, std::string_view>) {
+      // NOTE: returns the RAW on-the-wire bytes between the quotes — escape
+      // sequences (\n, \", \uXXXX, …) are NOT decoded (this is a zero-copy view
+      // into the source).  Use decoded() if you need the logical string value.
       if (doc_->tape[idx_].type() != TapeNodeType::StringRaw)
         throw std::runtime_error("qbuem::Value::as<string_view>: not a string");
       const TapeNode &nd = doc_->tape[idx_];
       return std::string_view(doc_->source.data() + nd.offset, nd.length());
     } else if constexpr (std::is_same_v<T, std::string>) {
+      // Like as<string_view>, RAW (un-decoded) bytes — just owned.  Use
+      // decoded() for the unescaped logical value.
       return std::string(as<std::string_view>());
     } else {
       static_assert(sizeof(T) == 0, "qbuem::Value::as<T>: unsupported type");
     }
+  }
+
+  // decoded(): the logical string value with JSON escape sequences DECODED
+  // (\" \\ \/ \b \f \n \r \t and \uXXXX, including surrogate pairs → UTF-8).
+  // Unlike as<std::string>() (which returns the raw on-the-wire slice), this
+  // returns what the JSON string actually denotes.  Throws if the value is not
+  // a string.  O(n), allocates.
+  [[nodiscard]] std::string decoded() const {
+    std::string_view raw = as<std::string_view>();
+    return detail::json_unescape(raw);
   }
 
   // try_as<T>(): non-throwing variant — returns std::nullopt on any error.
@@ -9176,7 +9270,7 @@ template <typename T> inline void NexusScanner::fill(T &obj) {
 } // namespace json::detail
 
 // read / write / fuse helpers
-template <typename T> T read(::std::string_view json) {
+template <typename T> [[nodiscard]] T read(::std::string_view json) {
   Document doc;
   Value root = json::parse_reuse(doc, json);
   T obj{};
@@ -9184,7 +9278,7 @@ template <typename T> T read(::std::string_view json) {
   return obj;
 }
 
-template <typename T> T fuse(::std::string_view json) {
+template <typename T> [[nodiscard]] T fuse(::std::string_view json) {
   T obj{};
   json::detail::NexusScanner scanner{json.data(), json.data() + json.size(), json.data()};
   scanner.fill(obj);
@@ -9207,7 +9301,7 @@ template <typename T> T fuse(::std::string_view json) {
 /// Typical usage: use fuse_strict() during development / unit tests, then
 /// switch to fuse() once the schema is validated.
 /// See docs/guide/nexus-diagnostics.md for a full guide.
-template <typename T> T fuse_strict(::std::string_view json) {
+template <typename T> [[nodiscard]] T fuse_strict(::std::string_view json) {
   json::detail::nexus_strict_mode() = true;
   try {
     T obj{};
@@ -9227,7 +9321,7 @@ template <typename T> T fuse_strict(::std::string_view json) {
   }
 }
 
-template <typename T>::std::string write(const T &obj) {
+template <typename T> [[nodiscard]] ::std::string write(const T &obj) {
   ::std::string out;
   out.reserve(512);
   ::qbuem::json::detail::append_json(out, obj);
@@ -9237,7 +9331,7 @@ template <typename T>::std::string write(const T &obj) {
 // write(obj, indent) — pretty-printed variant.
 // Serializes obj to compact JSON, then re-parses and formats with indent spaces
 // per level. Use write(obj) for hot paths; this variant is for human-readable output.
-template <typename T>::std::string write(const T &obj, int indent) {
+template <typename T> [[nodiscard]] ::std::string write(const T &obj, int indent) {
   ::std::string compact = write(obj);
   Document tmp;
   Value root = parse(tmp, compact);

--- a/include/qbuem_json/qbuem_json.hpp
+++ b/include/qbuem_json/qbuem_json.hpp
@@ -8125,11 +8125,17 @@ concept HasNexusPulse =
     requires(std::string_view key, const char *&p, const char *end, T &t) {
   nexus_pulse(key, p, end, t);
 };
-// Fast variant: dispatch on a pre-computed uint64 key hash (skips runtime hash)
+// Fast variant: dispatch on a pre-computed uint64 key hash (skips runtime hash).
+// NOTE: the signature here MUST track nexus_pulse_h's real arity — it gained a
+// string_view `key` parameter (used to byte-verify the hash match against the
+// field name, defeating hash-collision field spoofing).  If this requires-clause
+// lags behind, the concept silently evaluates false and NexusScanner::fill()
+// falls back to the slow read_key()+separate-hash path (a ~15% fuse<T> regression
+// that is functionally correct, so no test catches it).
 template <typename T>
-concept HasNexusPulseH =
-    requires(uint64_t h, const char *&p, const char *end, T &t) {
-  nexus_pulse_h(h, p, end, t);
+concept HasNexusPulseH = requires(uint64_t h, ::std::string_view key,
+                                  const char *&p, const char *end, T &t) {
+  nexus_pulse_h(h, key, p, end, t);
 };
 
 // ── Forward declarations

--- a/tests/repro_bugs.cpp
+++ b/tests/repro_bugs.cpp
@@ -92,6 +92,18 @@ QBUEM_JSON_FIELDS(TreeNode, v, kids)
 struct AbcRec { long a; std::string b; std::string c; };
 QBUEM_JSON_FIELDS(AbcRec, a, b, c)
 
+// Performance regression guard: NexusScanner::fill() has a fast path that
+// computes the key hash *during* the key scan (read_key_h) and dispatches via
+// nexus_pulse_h — gated on the HasNexusPulseH concept.  If that concept's
+// requires-clause ever drifts out of sync with nexus_pulse_h's real arity, it
+// silently evaluates false and every struct decode falls back to a slow
+// double-scan (read_key + a separate fast_key_hash) — a ~15% fuse<T> regression
+// that is functionally correct, so no runtime test catches it.  Assert the fast
+// path stays enabled for a normal QBUEM_JSON_FIELDS struct.
+static_assert(qbuem::json::detail::HasNexusPulseH<AbcRec>,
+              "Nexus fast hash-dispatch path is disabled — HasNexusPulseH must "
+              "track nexus_pulse_h's signature (else ~15% fuse<T> regression)");
+
 // Bug 1: Segfault after moving Document
 TEST(ReproBugs, MoveDocumentSegfault) {
   Document doc;

--- a/tests/repro_bugs.cpp
+++ b/tests/repro_bugs.cpp
@@ -30,6 +30,14 @@ QBUEM_JSON_FIELDS(FuseVec, v)
 struct U64Rec { uint64_t x; };
 QBUEM_JSON_FIELDS(U64Rec, x)
 
+// Structs for the Nexus security regression tests.
+struct AdminRec { long is_admin_lvl; std::string owner; };
+QBUEM_JSON_FIELDS(AdminRec, is_admin_lvl, owner)
+struct TreeNode { long v; std::vector<TreeNode> kids; };
+QBUEM_JSON_FIELDS(TreeNode, v, kids)
+struct AbcRec { long a; std::string b; std::string c; };
+QBUEM_JSON_FIELDS(AbcRec, a, b, c)
+
 // Bug 1: Segfault after moving Document
 TEST(ReproBugs, MoveDocumentSegfault) {
   Document doc;
@@ -431,8 +439,9 @@ TEST(DataIntegrity, InsertEscapesStringContent) {
   Value root2 = parse(doc, "{}");
   char ctrl[] = {(char)0x01, (char)0x1f};
   root2.insert("c", std::string_view(ctrl, sizeof(ctrl)));
+  const std::string out2 = root2.dump(); // hold: parse() borrows the buffer
   Document d2;
-  EXPECT_NO_THROW(parse(d2, root2.dump()));
+  EXPECT_NO_THROW(parse(d2, out2));
 }
 
 TEST(DataIntegrity, SetEscapesStringContent) {
@@ -440,8 +449,9 @@ TEST(DataIntegrity, SetEscapesStringContent) {
   Value root = parse(doc, R"({"k":"orig"})");
   root["k"].set(std::string_view("x\"y\\z\n"));
   EXPECT_EQ(root.dump(), R"({"k":"x\"y\\z\n"})");
+  const std::string out = root.dump(); // hold: parse() borrows the buffer
   Document d2;
-  EXPECT_NO_THROW(parse(d2, root.dump()));
+  EXPECT_NO_THROW(parse(d2, out));
 }
 
 // ── INTEGRITY: the relaxed parser accepts separator-less tokens, so the
@@ -650,6 +660,52 @@ TEST(TypeSafety, SerializeUnsigned64RoundTrips) {
   std::string j = qbuem::write(s);
   EXPECT_NE(j.find("18446744073709551615"), std::string::npos);
   EXPECT_EQ(qbuem::read<U64Rec>(j).x, umax);
+}
+
+// ── SECURITY: dump_changes_ used a fixed Frame stk[64] while the parser allows
+// nesting to 1088; a valid deep doc + any mutation + dump() smashed the stack.
+TEST(SecurityHardening, DumpChangesDeepNestNoStackSmash) {
+  std::string j(300, '[');
+  j += "1";
+  j.append(300, ']');
+  Document doc;
+  Value r = parse(doc, j);
+  Value cur = r;
+  for (int i = 0; i < 299; ++i)
+    cur = cur[size_t(0)];
+  cur.push_back(9); // route dump() to dump_changes_
+  EXPECT_NO_THROW(r.dump());
+}
+
+// ── SECURITY: Nexus dispatch is by key hash; the hash is collision-prone, so a
+// colliding untrusted key must NOT be routed into a field it doesn't name.
+TEST(SecurityHardening, NexusHashCollisionNoFieldSpoof) {
+  // "iS_adMin_Lvl" collides with "is_admin_lvl" under fast_key_hash.
+  auto r = qbuem::fuse<AdminRec>(R"({"owner":"bob","iS_adMin_Lvl":99})");
+  EXPECT_EQ(r.is_admin_lvl, 0); // spoof rejected (not 99)
+  auto r2 = qbuem::fuse<AdminRec>(R"({"is_admin_lvl":7,"owner":"x"})");
+  EXPECT_EQ(r2.is_admin_lvl, 7); // legitimate key still works
+}
+
+// ── SECURITY: Nexus typed recursion (recursive struct) must be depth-bounded,
+// not crash the stack on deeply-nested untrusted input.
+TEST(SecurityHardening, NexusDeepRecursionRejected) {
+  const int D = 30000;
+  std::string j;
+  for (int i = 0; i < D; ++i)
+    j += "{\"kids\":[";
+  j += "{\"v\":1}";
+  for (int i = 0; i < D; ++i)
+    j += "]}";
+  EXPECT_THROW(qbuem::fuse<TreeNode>(j), std::runtime_error);
+}
+
+// ── SECURITY/INTEGRITY: a type-mismatched value (string where number expected)
+// must not desync the cursor and silently drop the rest of the object.
+TEST(SecurityHardening, NexusCursorNoFieldDrop) {
+  auto r = qbuem::fuse<AbcRec>(R"({"a":"X","b":"BEE","c":"CEE"})");
+  EXPECT_EQ(r.b, "BEE");
+  EXPECT_EQ(r.c, "CEE");
 }
 
 int main(int argc, char **argv) {

--- a/tests/repro_bugs.cpp
+++ b/tests/repro_bugs.cpp
@@ -5,6 +5,8 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <cmath>
+#include <cstdint>
 
 // A minimized (ASCII-sanitized) heterogeneous-sibling-objects document derived
 // from twitter.json, used by the KeyLenCache regression test below.
@@ -23,6 +25,10 @@ QBUEM_JSON_FIELDS(FuseStr, s, o)
 // Struct with a vector to exercise the Nexus sequence-decoding loop.
 struct FuseVec { std::vector<int> v; };
 QBUEM_JSON_FIELDS(FuseVec, v)
+
+// Struct with an unsigned-64 field for serialize round-trip tests.
+struct U64Rec { uint64_t x; };
+QBUEM_JSON_FIELDS(U64Rec, x)
 
 // Bug 1: Segfault after moving Document
 TEST(ReproBugs, MoveDocumentSegfault) {
@@ -580,6 +586,70 @@ TEST(DataIntegrity, FuseStrictRejectsTrailingContent) {
   EXPECT_THROW(fuse_strict<FuseRec>(R"({"a":1,"b":2}garbage)"),
                std::runtime_error);
   EXPECT_NO_THROW(fuse_strict<FuseRec>(R"({"a":1,"b":2}   )"));
+}
+
+// ── TYPE SAFETY: as<narrow-integer> must range-check, not silently truncate.
+// Previously as<uint8_t>(256) returned 0 and as<uint8_t>(-1) returned 255
+// (static_cast wrap) — a silent data-corruption hazard.
+TEST(TypeSafety, NarrowIntegerOverflowThrows) {
+  Document doc;
+  Value r = parse(doc, "[256, -1, 1000, 127, 255, 32768, -129]");
+  EXPECT_EQ(r[3].as<int8_t>(), 127);                     // in range
+  EXPECT_EQ(r[4].as<uint8_t>(), 255);                    // in range
+  EXPECT_EQ(r[4].as<uint16_t>(), 255u);                  // widening fine
+  EXPECT_THROW(r[0].as<int8_t>(), std::runtime_error);   // 256 > int8 max
+  EXPECT_THROW(r[0].as<uint8_t>(), std::runtime_error);  // 256 > uint8 max
+  EXPECT_THROW(r[2].as<uint8_t>(), std::runtime_error);  // 1000 > uint8 max
+  EXPECT_THROW(r[1].as<uint8_t>(), std::runtime_error);  // -1 into unsigned
+  EXPECT_THROW(r[1].as<uint32_t>(), std::runtime_error); // -1 into unsigned
+  EXPECT_THROW(r[5].as<int16_t>(), std::runtime_error);  // 32768 > int16 max
+  EXPECT_THROW(r[6].as<int8_t>(), std::runtime_error);   // -129 < int8 min
+}
+
+// ── TYPE SAFETY: the full uint64 range must be readable; cross-sign overflow
+// must throw.  Previously as<uint64_t> parsed via int64_t and could not read
+// values above INT64_MAX (it threw on UINT64_MAX).
+TEST(TypeSafety, FullUint64Range) {
+  Document doc;
+  Value r = parse(doc, "[18446744073709551615, 9223372036854775808, "
+                       "9223372036854775807]");
+  EXPECT_EQ(r[0].as<uint64_t>(), 18446744073709551615ULL); // UINT64_MAX
+  EXPECT_EQ(r[1].as<uint64_t>(), 9223372036854775808ULL);  // INT64_MAX + 1
+  EXPECT_EQ(r[2].as<int64_t>(), 9223372036854775807LL);    // INT64_MAX
+  EXPECT_THROW(r[0].as<int64_t>(), std::runtime_error);    // UINT64_MAX > int64
+  EXPECT_THROW(r[1].as<int64_t>(), std::runtime_error);    // INT64_MAX+1 > int64
+}
+
+// ── TYPE SAFETY: float extremes (overflow -> inf, underflow -> 0, signed zero).
+TEST(TypeSafety, FloatExtremes) {
+  Document doc;
+  Value r = parse(doc, "[1e400, 1e-400, -0, 5e-324, -1e-400]");
+  EXPECT_TRUE(std::isinf(r[0].as<double>()));            // overflow -> +inf
+  EXPECT_EQ(r[1].as<double>(), 0.0);                     // underflow -> 0
+  EXPECT_TRUE(std::signbit(r[2].as<double>()));          // -0 sign preserved
+  EXPECT_GT(r[3].as<double>(), 0.0);                     // smallest subnormal
+  EXPECT_TRUE(std::signbit(r[4].as<double>()));          // -0 from neg underflow
+}
+
+// ── TYPE SAFETY: serializing an unsigned value above INT64_MAX must not emit
+// "-1".  Value::set/insert/scalar_to_json_ cast to int64_t; fixed to dispatch
+// on signedness like the struct writer already did.
+TEST(TypeSafety, SerializeUnsigned64RoundTrips) {
+  const uint64_t umax = 18446744073709551615ULL;
+  Document doc;
+  Value r = parse(doc, "{}");
+  r.insert("u", umax);
+  const std::string dumped = r.dump(); // hold: parse() keeps a view into this
+  EXPECT_NE(dumped.find("18446744073709551615"), std::string::npos);
+  Document d2;
+  Value r2 = parse(d2, dumped);
+  EXPECT_EQ(r2["u"].as<uint64_t>(), umax);
+
+  // struct write path (was already correct — guard against regression)
+  U64Rec s{umax};
+  std::string j = qbuem::write(s);
+  EXPECT_NE(j.find("18446744073709551615"), std::string::npos);
+  EXPECT_EQ(qbuem::read<U64Rec>(j).x, umax);
 }
 
 int main(int argc, char **argv) {

--- a/tests/repro_bugs.cpp
+++ b/tests/repro_bugs.cpp
@@ -708,6 +708,27 @@ TEST(SecurityHardening, NexusCursorNoFieldDrop) {
   EXPECT_EQ(r.c, "CEE");
 }
 
+// ── API: decoded() returns the unescaped logical string; as<string> stays raw.
+TEST(ApiUsability, DecodedUnescapesString) {
+  Document doc;
+  Value r = parse(doc, R"({"s":"a\nb\t\"\\\/Aé"})");
+  // expected: a <nl> b <tab> " \ / A é(0xC3 0xA9)
+  std::string expected = "a";
+  expected += '\n'; expected += 'b'; expected += '\t';
+  expected += '"'; expected += '\\'; expected += '/'; expected += 'A';
+  expected += static_cast<char>(0xC3); expected += static_cast<char>(0xA9);
+  EXPECT_EQ(r["s"].decoded(), expected);
+  // as<string_view> remains the RAW on-the-wire slice
+  EXPECT_EQ(std::string(r["s"].as<std::string_view>()).find("\\n"), 1u);
+
+  // surrogate pair 😀 -> U+1F600 (😀 = F0 9F 98 80)
+  Value r2 = parse(doc, R"({"e":"😀"})");
+  std::string emoji;
+  emoji += static_cast<char>(0xF0); emoji += static_cast<char>(0x9F);
+  emoji += static_cast<char>(0x98); emoji += static_cast<char>(0x80);
+  EXPECT_EQ(r2["e"].decoded(), emoji);
+}
+
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/tests/repro_bugs.cpp
+++ b/tests/repro_bugs.cpp
@@ -14,6 +14,60 @@
 
 using namespace qbuem;
 
+// ── Compile-time UAF-guard regression ───────────────────────────────────────
+// Every zero-copy parse entry point returns a Value that views into its input
+// buffer.  Passing a *temporary* std::string would dangle, so each overload has
+// a deleted `const std::string&&` companion that turns the misuse into a compile
+// error.  These static_asserts lock that contract in: an lvalue (kept alive) is
+// invocable, but a prvalue std::string is NOT.  A requires-expression that would
+// select a deleted overload is ill-formed, hence unsatisfied — so the negative
+// asserts succeed exactly when the guards are present.  If anyone drops a guard,
+// this file stops compiling.
+// NOTE: every detector is parameterized on the document type `Doc` so the call
+// lives in a *dependent* context.  There, selecting a deleted overload is a soft
+// (SFINAE) failure that makes the requires-expression evaluate to false; written
+// inline with a concrete type it would instead be a hard "call to deleted
+// function" error.  So the templates below are load-bearing, not stylistic.
+namespace {
+template <class Doc>
+inline constexpr bool lvalue_ok =
+    requires(Doc &d, std::string &s) { qbuem::json::parse_reuse(d, s); };
+template <class Doc>
+inline constexpr bool reuse_rvalue_rejected =
+    !requires(Doc &d) { qbuem::json::parse_reuse(d, std::string{"{}"}); };
+template <class Doc>
+inline constexpr bool partial_rvalue_rejected =
+    !requires(Doc &d) { qbuem::json::parse_partial(d, std::string{"{}"}); };
+template <class Doc>
+inline constexpr bool strict_dv_rvalue_rejected =
+    !requires(Doc &d) { qbuem::json::rfc8259::parse_strict(d, std::string{"{}"}); };
+template <class Doc>
+inline constexpr bool parse_rvalue_rejected =
+    !requires(Doc &d) { qbuem::parse(d, std::string{"{}"}); };
+template <class Doc>
+inline constexpr bool parse_strict_rvalue_rejected =
+    !requires(Doc &d) { qbuem::parse_strict(d, std::string{"{}"}); };
+
+// Positive: an lvalue (kept alive) is invocable on both document handles.
+static_assert(lvalue_ok<qbuem::Document>, "Document& lvalue parse must compile");
+static_assert(lvalue_ok<qbuem::json::DocumentView>,
+              "DocumentView& lvalue parse must compile");
+// Negative: a prvalue std::string selects the deleted UAF guard on every
+// zero-copy entry point (Document& family + DocumentView& family).
+static_assert(reuse_rvalue_rejected<qbuem::Document>,
+              "parse_reuse(Document&, std::string&&) must be deleted (UAF)");
+static_assert(reuse_rvalue_rejected<qbuem::json::DocumentView>,
+              "parse_reuse(DocumentView&, std::string&&) must be deleted (UAF)");
+static_assert(partial_rvalue_rejected<qbuem::json::DocumentView>,
+              "parse_partial(DocumentView&, std::string&&) must be deleted (UAF)");
+static_assert(strict_dv_rvalue_rejected<qbuem::json::DocumentView>,
+              "parse_strict(DocumentView&, std::string&&) must be deleted (UAF)");
+static_assert(parse_rvalue_rejected<qbuem::Document>,
+              "parse(Document&, std::string&&) must be deleted (UAF)");
+static_assert(parse_strict_rvalue_rejected<qbuem::Document>,
+              "parse_strict(Document&, std::string&&) must be deleted (UAF)");
+} // namespace
+
 // Struct used by the Nexus (fuse) data-integrity tests below.
 struct FuseRec { int a; long b; };
 QBUEM_JSON_FIELDS(FuseRec, a, b)


### PR DESCRIPTION
## Summary

Second hardening wave for **qbuem-json**, building on #118. Four commits that fix **12 untrusted-input defects** — type-safety silent corruption, nine memory-safety / DoS / type-confusion vulnerabilities (found by parallel security review + empirical ASan attack testing), and the zero-copy use-after-free foot-gun on **every** parse entry point — plus an API-usability follow-up. The library parses arbitrary external JSON, so each of these is security-relevant.

All logic lives in the single header (`include/qbuem_json/qbuem_json.hpp`); every fix ships with a regression test. **No parser hot-path regression.**

## Commits

1. `fix(types)` — range-check integer accessors, full uint64, fix unsigned serialize
2. `security` — stack overflow, UAF, OOB read, recursion DoS, hash spoofing + UAF API foot-gun (9 vulns)
3. `api` — `decoded()` accessor, document raw `as<string>`, `[[nodiscard]]` producers
4. `security` — close the UAF foot-gun on *all* zero-copy entry points + thread-safety docs

## What's fixed, by class

### Type safety — worst-case min/max/overflow/underflow audit (3 silent-corruption defects)
- **`as<NarrowInteger>` silently truncated** out-of-range values: `as<uint8_t>("256") → 0`, `as<uint8_t>("-1") → 255`, `as<int16_t>("32768") → -32768`. The accessor parsed into `int64_t` then `static_cast<T>`. Now routed through `to_integral_checked<T>`, which range-checks against the target's `[min,max]` and **throws** on overflow / negative-into-unsigned instead of wrapping.
- **`as<unsigned>` couldn't read above `INT64_MAX`** (threw on `UINT64_MAX`). Unsigned targets now parse via `uint64_t`, so the full unsigned range is readable; `read<T>` inherits this.
- **`set`/`insert`/`scalar_to_json_` serialized unsigned > INT64_MAX as `"-1"`** (cast to `int64_t` before `to_chars`). Now dispatch on signedness, so `uint64` values serialize and round-trip exactly. (Floats were already correct — overflow→inf, underflow→0, signed-zero/subnormals preserved — verified, no change.)

### Memory safety (found by security review + ASan attack testing)
- **CRITICAL stack-buffer-overflow** in `dump_changes_`: a fixed `Frame stk[64]` against a parser that nests to 1088 — a valid doc nested >64 deep + any mutation + `dump()` smashed the stack (verified under ASan). Now a heap vector sized to the parser's max depth.
- **HIGH use-after-free** in `get_synthetic`: the cached synthetic document's source viewed a transient argument (an `additions_` entry that `erase`/`merge` frees) while `synthetic_docs_` was never invalidated. Now points at the map's stable key.
- **HIGH out-of-bounds read** in the AVX-512 `skip_to_action` SWAR-8 pre-gate: `load64()` read 8 bytes with only `p_ < end_` guarded. Added the `p_ + 8 <= end_` guard.
- Inputs **> 4 GiB** rejected up front (32-bit tape offsets would wrap).

### Denial of service
- **Nexus typed recursion → SIGSEGV**: recursive structs / `Optional` / `Map` / `Tuple` / `Seq` decoded without a depth cap (verified crash on deeply-nested untrusted input). Depth guard added at the recursive branches; scalars pay nothing.
- **`dump_pretty_` recursion → stack exhaustion** (~1088 frames on small thread stacks). Falls back to the iterative compact dump past a depth cap.

### Type confusion / integrity
- **HIGH Nexus field spoofing**: hash-only field dispatch let a colliding untrusted key route into the wrong struct field (verified exploit: `"iS_adMin_Lvl"` sets `is_admin_lvl`). Now verifies the key bytes after the hash match (one short compare per object key).
- **Nexus cursor desync**: a string value where a number was expected left the cursor unadvanced and silently dropped the rest of the object. Now routes through `skip_direct` so following fields survive.

### API safety — zero-copy use-after-free foot-gun (closed on every entry point)
`parse*` borrow the input `string_view`, so `auto v = parse(doc, get_json())` (a temporary) was a silent UAF. The fix lands in two steps:
- Commit 2 deletes the rvalue-`std::string` overload on the **`Document&`** family (`parse` / `parse_reuse` / `parse_strict`), turning the misuse into a compile error; a `const char*` overload keeps string literals working.
- Commit 4 extends the same guard to the lower-level but still public **`DocumentView&`** family (`json::parse_reuse` / `json::parse_partial` / `rfc8259::parse_strict`), which `qbuem::json::parse_reuse(view, make_string())` could still UAF through. A compile-time `static_assert` regression now locks **all six** deleted guards (an lvalue stays invocable; a prvalue `std::string` is rejected) — drop any guard and the test stops compiling. The detectors are parameterized on the document type so the call sits in a dependent context, where selecting a deleted overload is an observable SFINAE failure rather than a hard error.
- Also: `std::terminate` no longer escapes `operator[] → get_synthetic → parse_reuse` (a throwing call from a `noexcept` accessor) — `get_synthetic` returns `nullptr` on parse failure.
- The zero-copy lifetime **and thread-safety / aliasing** contract is documented at the call site: one `Document` is single-threaded; its `Value`s alias the immutable tape and may be read concurrently, but any mutation or reparse must quiesce all readers.

### API usability
- **`decoded()`** — new accessor returning the *unescaped* logical string (`\" \\ \/ \b \f \n \r \t` and `\uXXXX` incl. surrogate pairs → UTF-8). `as<std::string>()` / `as<std::string_view>()` return the raw on-the-wire slice by design (zero-copy); that's now documented and `decoded()` is offered for the logical value.
- `[[nodiscard]]` on `read<T>` / `fuse<T>` / `fuse_strict<T>` / `write` — discarding an owned decode/serialize result is virtually always a bug.

## Performance

**DOM parse**: no hot-path regression (twitter/citm medians at parity with `main`; the integer range-check is on the cold accessor path, not the parse loop). A sound verified-byte key cache was prototyped to claw back the (already-merged in #118) `KeyLenCache` removal cost, but **reverted**: it helped homogeneous data (citm −2.2%) yet regressed heterogeneous data (twitter **+4.3%**) and is dead code on the primary AVX-512 `parse_staged` path — it failed the "no degradation" bar.

**Nexus `fuse<T>`**: the field-spoofing fix gave `nexus_pulse_h` a new `key` parameter but left the `HasNexusPulseH` concept checking the old 4-arg signature, so it silently evaluated false and every struct decode fell to a slow double-scan — a **~15% `fuse<T>` regression** that no test caught (the slow path is functionally correct). Fixed by syncing the concept to the real arity, re-enabling the single-pass `read_key_h` path: the struct-array median recovers from ~717 µs to ~634 µs vs ~623 µs pre-security-commit. A compile-time `static_assert(HasNexusPulseH<…>)` now prevents this fast path from ever silently regressing again. The residual ~1.5% is the genuine recursion-bound + per-key byte-verify cost, kept for safety.

## Tests added

`TypeSafety.{NarrowIntegerOverflowThrows, FullUint64Range, FloatExtremes, SerializeUnsigned64RoundTrips}`, `SecurityHardening.{DumpChangesDeepNestNoStackSmash, NexusHashCollisionNoFieldSpoof, NexusDeepRecursionRejected, NexusCursorNoFieldDrop}`, `ApiUsability.DecodedUnescapesString`, plus the compile-time UAF-guard `static_assert` suite.

## Verification (this branch, freshly run)

- **547 / 547** unit + regression tests pass under **Release** and **ASan + UBSan** (macOS Apple Silicon).
- **JSONTestSuite differential** (rebuilt against this header): 95/95 valid accepted & round-trip-correct, **0/188** invalid accepted by the strict validator, **0 crashes**.
- **libFuzzer smoke** (parse / dom / nexus / direct / rfc8259 / float, 20 s each): crash-free.
- UAF guards: lvalue path compiles & runs; all rvalue-temporary calls rejected at compile time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
