### PR TITLE
docs: document parse_error, decoded(), strict UTF-8 & duplicate-key semantics (+ stale-fact fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
   <!-- Testing -->
   <p>
-    <a href="https://qbuem.com/qbuem-json/guide/correctness"><img src="https://img.shields.io/badge/tests-521%20passing-brightgreen" alt="521 tests passing"></a>
+    <a href="https://qbuem.com/qbuem-json/guide/correctness"><img src="https://img.shields.io/badge/tests-558%20passing-brightgreen" alt="558 tests passing"></a>
     <a href="https://qbuem.com/qbuem-json/guide/correctness#fuzz-testing"><img src="https://img.shields.io/badge/fuzz-11%20libFuzzer%20targets-orange" alt="11 libFuzzer targets"></a>
   </p>
 
@@ -88,6 +88,7 @@ std::string json = qbuem::write(player);
 * **Single Header** — Drop `qbuem_json.hpp` into your project and you're ready. Zero external dependencies.
 * **STL Support** — `std::vector`, `std::map`, `std::optional`, `std::tuple`, `std::variant` and more work out of the box.
 * **Three-stage float parsing** — Eisel-Lemire (~98.8 %) → Russ Cox Unrounded Scaling (~1.2 %) → `std::strtod` (subnormals only). `parse(serialize(x)) == x` for all finite doubles.
+* **Hardened for untrusted input** — strict mode validates UTF-8 well-formedness (rejects overlong / surrogate / truncated sequences, RFC 8259 §8.1); parse failures throw a typed `qbuem::parse_error` with `offset()`; zero-copy use-after-free misuse is a **compile error**. Continuously fuzzed (11 libFuzzer targets) and sanitized (ASan/UBSan/TSan across x86_64 / aarch64 / Apple Silicon).
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,22 +54,45 @@ Out of scope:
 
 ## Security Hardening
 
-qbuem-json is continuously tested for memory safety:
+All parser/serializer entry points are designed to treat their input as
+**untrusted**. The hardening posture includes:
+
+- **Memory safety** — depth caps on every recursive path (parser, validator,
+  Nexus typed decode, pretty-printer) prevent stack exhaustion; inputs larger
+  than 4 GiB are rejected up front (32-bit tape offsets); the zero-copy
+  lifetime contract is enforced at **compile time** — passing a temporary
+  `std::string` to a borrowing `parse*` overload is a compile error, not a
+  silent use-after-free.
+- **Denial of service** — recursion and output-size blow-ups are bounded;
+  pathological inputs cannot drive unbounded memory growth.
+- **Type confusion** — the Nexus engine verifies actual key bytes after its
+  hash dispatch, so a hash-colliding untrusted key cannot be routed into the
+  wrong struct field (field spoofing).
+- **Encoding** — strict mode (`parse_strict` / `rfc8259::validate`) rejects
+  malformed UTF-8 (overlong encodings, UTF-8-encoded surrogates, code points
+  beyond U+10FFFF, lone continuation/truncated sequences) per RFC 8259 §8.1;
+  `decoded()` substitutes U+FFFD for lone surrogates so its output is always
+  valid UTF-8.
+- **Diagnostics** — invalid input throws a typed `qbuem::parse_error`
+  (a `std::runtime_error` with an `offset()` byte position).
+
+These are continuously verified:
 
 - **AddressSanitizer (ASan)** — heap/stack overflow, use-after-free, memory leaks
 - **UndefinedBehaviorSanitizer (UBSan)** — integer overflow, null deref, misaligned
   access, invalid enum
 - **ThreadSanitizer (TSan)** — data races, lock-order inversions
 
-These run on every pull request and push to `main` via the
+ASan/UBSan and TSan run on every pull request and push to `main` across
+**x86_64, aarch64, and Apple Silicon** via the
 [Sanitizers CI workflow](https://github.com/qbuem/qbuem-json/actions/workflows/sanitizers.yml).
 
-Three [libFuzzer](https://llvm.org/docs/LibFuzzer.html) targets fuzz the parser
-continuously:
-
-- `fuzz_dom` — DOM parser with arbitrary input
-- `fuzz_parse` — Nexus / struct-mapping path
-- `fuzz_rfc8259` — strict RFC 8259 parser
+Eleven [libFuzzer](https://llvm.org/docs/LibFuzzer.html) targets fuzz the parser,
+serializer, and struct-mapping paths; nine run as a blocking
+[Fuzz CI gate](https://github.com/qbuem/qbuem-json/actions/workflows/fuzz.yml) on
+every change (with a deeper weekly run), including `fuzz_parse`, `fuzz_dom`,
+`fuzz_nexus`, `fuzz_direct`, `fuzz_pmr`, `fuzz_patch`, `fuzz_api_stress`,
+`fuzz_rfc8259`, and `fuzz_float`.
 
 ## Attribution
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -194,7 +194,7 @@ export default withMermaid(
                             'C++20 concepts-based API',
                             'RFC 8259, RFC 6901, RFC 6902 compliant',
                             'IEEE 754 round-trip float correctness',
-                            '521 passing tests, 11 libFuzzer targets',
+                            '558 passing tests, 11 libFuzzer targets',
                             'STL container support (vector, map, optional, tuple, variant)',
                             'Up to 2.9 GB/s parsing, 7.2 GB/s serialization',
                             'Apache 2.0 license — free for commercial use',

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,6 +1,6 @@
 # API Reference
 
-A complete reference for all public APIs in qbuem-json v1.0.5.
+A complete reference for all public APIs in qbuem-json v1.0.7.
 
 > [!TIP]
 > Looking for auto-generated class/struct documentation? The **[Doxygen Reference](/qbuem-json/api/reference/index.html)** is rebuilt automatically whenever `qbuem_json.hpp` changes and deployed to Pages alongside this guide.
@@ -83,15 +83,16 @@ while (running) {
 
 ### `qbuem::parse_strict(doc, json)` — RFC 8259 Strict Parse
 
-Performs strict RFC 8259 validation before parsing. Rejects trailing commas, leading zeros, lone surrogates, and more.
+Performs strict RFC 8259 validation before parsing. Rejects trailing commas, leading zeros, single-quoted strings, trailing garbage, **and malformed UTF-8** (overlong encodings, UTF-8-encoded surrogates, code points > U+10FFFF, lone continuation bytes). Throws `qbuem::parse_error`.
 
 ```cpp
 qbuem::Document doc;
 try {
     auto root = qbuem::parse_strict(doc, R"({"key": "value"})"); // OK
     auto bad  = qbuem::parse_strict(doc, "[1, 2,]");             // throws!
-} catch (const std::runtime_error& e) {
-    std::cerr << e.what() << "\n"; // RFC 8259 violation at offset 7
+} catch (const qbuem::parse_error& e) {
+    std::cerr << e.what()        // "RFC 8259 violation at offset 6: trailing comma in array"
+              << " @ " << e.offset() << "\n"; // 6
 }
 ```
 
@@ -99,14 +100,34 @@ try {
 
 ### `qbuem::rfc8259::validate(json)` — Validate Only (No Parse)
 
-Validates JSON text without building a DOM. Throws `std::runtime_error` on violation.
+Validates JSON text (syntax + UTF-8 well-formedness) without building a DOM. Throws `qbuem::parse_error` on violation.
 
 ```cpp
 try {
     qbuem::rfc8259::validate(R"({"valid": true})");  // OK — no throw
     qbuem::rfc8259::validate("[1, 2,]");              // throws
-} catch (const std::runtime_error& e) {
-    std::cerr << e.what() << "\n";
+} catch (const qbuem::parse_error& e) {
+    std::cerr << e.what() << " @ " << e.offset() << "\n";
+}
+```
+
+---
+
+### `qbuem::parse_error` — Exception Type
+
+Thrown by `parse`, `parse_reuse`, `parse_strict`, `read<T>`, `fuse<T>`, and `rfc8259::validate` on invalid input. Derives from `std::runtime_error`, so existing `catch (const std::runtime_error&)` / `catch (const std::exception&)` blocks keep working. Adds:
+
+| Member | Returns | Meaning |
+| :--- | :--- | :--- |
+| `offset()` | `std::size_t` | 0-based byte position of the failure (== input size on premature end) |
+| `what()` | `const char*` | Human-readable message, including the offset |
+
+```cpp
+try {
+    qbuem::Document doc;
+    qbuem::parse(doc, "[1, 2,"); // truncated
+} catch (const qbuem::parse_error& e) {
+    log("parse failed at byte %zu: %s", e.offset(), e.what());
 }
 ```
 
@@ -231,6 +252,21 @@ bool         flag  = root["flag"].as<bool>();
 std::string_view sv = root["tag"].as<std::string_view>();
 
 // Throws std::runtime_error on type mismatch or missing key
+```
+
+### `.decoded()` — Unescaped Logical String
+
+`as<std::string>()` / `as<std::string_view>()` return the **raw** on-the-wire
+bytes (escapes **not** decoded — the `string_view` form is zero-copy). `decoded()`
+returns the logical value with `\" \\ \/ \b \f \n \r \t` and `\uXXXX` resolved
+(surrogate pairs → UTF-8; lone surrogates → U+FFFD, so the result is **always
+valid UTF-8**).
+
+```cpp
+auto v = qbuem::parse(doc, R"({"p":"C:\\tmp","e":"😀"})");
+std::string_view raw = v["p"].as<std::string_view>(); // C:\\tmp  (raw, zero-copy)
+std::string      log = v["p"].decoded();              // C:\tmp   (unescaped)
+std::string      em  = v["e"].decoded();              // 😀
 ```
 
 ### Implicit Conversion — `operator T()`

--- a/docs/guide/correctness.md
+++ b/docs/guide/correctness.md
@@ -104,6 +104,33 @@ The library ships two parsers:
 All `n_` tests use `parse_strict()`.  The lenient parser's extensions are
 explicitly documented so you can opt in intentionally.
 
+### UTF-8 well-formedness (RFC 8259 §8.1)
+
+`parse_strict()` / `rfc8259::validate()` validate that string content is
+**well-formed UTF-8**, not just syntactically valid JSON. Malformed byte
+sequences are rejected against the Unicode "well-formed UTF-8" table (Table 3-7):
+
+| Rejected | Example bytes |
+|:---|:---|
+| Overlong encodings | `C0 AF` (a non-shortest form of `/` — a filter-bypass vector) |
+| UTF-8-encoded surrogates | `ED A0 80` (U+D800) |
+| Code points > U+10FFFF | `F4 90 80 80` |
+| Lone continuation bytes | `80` |
+| Truncated sequences | `E2 9C` (3-byte lead, one byte short) |
+
+The **lenient** `parse()` is byte-transparent (it does not UTF-8-validate) so
+`as<std::string_view>()` can stay zero-copy. A lone surrogate written as a
+`\uXXXX` *escape* is accepted (RFC implementation-defined); `decoded()` then
+replaces it with U+FFFD so decoded output is always valid UTF-8.
+
+### Duplicate object keys
+
+RFC 8259 §4 says names *should* (not *must*) be unique, so duplicates are valid
+JSON and are accepted. Resolution is deterministic but engine-specific: the DOM
+(`operator[]`, `read<T>`) is **first-wins**; Nexus (`fuse<T>`) is **last-wins**
+(matching JavaScript / Python / Go). Reject or canonicalize upstream if duplicate
+keys are security-relevant.
+
 ---
 
 ## Memory safety — sanitizers

--- a/docs/guide/errors.md
+++ b/docs/guide/errors.md
@@ -35,16 +35,26 @@ try {
 
 ### Parse Errors
 
-A parse failure also throws `std::runtime_error`:
+A parse failure throws **`qbuem::parse_error`**. It derives from
+`std::runtime_error` — so existing `catch (const std::runtime_error&)` /
+`catch (const std::exception&)` blocks keep working — and adds an **`offset()`**
+method giving the 0-based byte position in the input where parsing failed (equal
+to the input size when the input ends prematurely):
 
 ```cpp
 try {
     qbuem::Document doc;
-    auto root = qbuem::parse(doc, "{malformed json!}"); // throws
-} catch (const std::runtime_error& e) {
-    std::cerr << "Parse failed: " << e.what() << "\n";
+    auto root = qbuem::parse(doc, "[1, 2,"); // truncated → throws
+} catch (const qbuem::parse_error& e) {
+    std::cerr << "Parse failed: " << e.what()      // "Invalid JSON at offset 6"
+              << " (byte " << e.offset() << ")\n";  // byte 6
 }
 ```
+
+`parse_error` is thrown by every parsing entry point — `parse`, `parse_reuse`,
+`parse_strict`, and the owning `read<T>()` / `fuse<T>()`. On the relaxed scalar
+path `offset()` is the exact failure cursor; on the AVX-512 staged path it is the
+offset just past the last fully consumed value.
 
 ---
 
@@ -138,7 +148,7 @@ v.type_name();   // "null", "bool", "int", "double", "string", "array", "object"
 
 ## 🔐 Strategy 4: RFC 8259 Strict Validation
 
-Use `qbuem::parse_strict()` or `qbuem::rfc8259::validate()` when you need to enforce strict JSON compliance (e.g., for security-sensitive input processing).
+Use `qbuem::parse_strict()` or `qbuem::rfc8259::validate()` when you need to enforce strict JSON compliance (e.g., for security-sensitive input processing). Strict failures also throw `qbuem::parse_error`, and `what()` includes both the offset and a human-readable reason.
 
 ```cpp
 #include <qbuem_json/qbuem_json.hpp>
@@ -146,8 +156,9 @@ Use `qbuem::parse_strict()` or `qbuem::rfc8259::validate()` when you need to enf
 // Validate without parsing (just check validity)
 try {
     qbuem::rfc8259::validate("[1, 2,]");  // trailing comma → throws
-} catch (const std::runtime_error& e) {
-    std::cerr << e.what(); // "RFC 8259 violation at offset 7: trailing comma"
+} catch (const qbuem::parse_error& e) {
+    std::cerr << e.what()        // "RFC 8259 violation at offset 6: trailing comma in array"
+              << " @ " << e.offset(); // 6
 }
 
 // Validate and parse in one step
@@ -155,10 +166,21 @@ try {
     qbuem::Document doc;
     auto root = qbuem::parse_strict(doc, R"({"key": "value"})"); // OK
     auto bad  = qbuem::parse_strict(doc, R"({"a": 01})");        // leading zero → throws
-} catch (const std::runtime_error& e) {
+} catch (const qbuem::parse_error& e) {
     std::cerr << "Strict parse failed: " << e.what() << "\n";
 }
 ```
+
+### Strict UTF-8 validation
+
+Beyond JSON *syntax*, strict mode also enforces RFC 8259 §8.1: the input must be
+**well-formed UTF-8**. It rejects malformed byte sequences in string content —
+overlong encodings (e.g. `C0 AF`, a classic filter-bypass form of `/`), UTF-8
+-encoded surrogates (`ED A0 80`), code points beyond U+10FFFF, lone continuation
+bytes, and truncated sequences. The **relaxed** parser (`parse` / `parse_reuse`)
+stays byte-transparent so `as<std::string_view>()` can return a zero-copy slice;
+use strict mode, or [`decoded()`](/guide/parsing#decoded-vs-raw-strings), when
+you need a UTF-8 guarantee.
 
 **Inputs rejected by strict mode:**
 
@@ -167,9 +189,16 @@ try {
 | `[1, 2,]` | Trailing comma |
 | `{"a": 01}` | Leading zero |
 | `{"key": 'val'}` | Single-quoted string |
-| `{"\\uD800": "x"}` | Lone surrogate |
+| `"…\xC0\xAF…"` | Overlong UTF-8 encoding |
+| `"…\xED\xA0\x80…"` | UTF-8-encoded surrogate |
+| `"…\x80…"` | Lone UTF-8 continuation byte |
 | `[1, 2} garbage` | Trailing garbage |
 | `` (empty) | Empty input |
+
+> A lone surrogate written as a `\uXXXX` **escape** (e.g. `"\uD800"`) is *accepted*
+> — RFC 8259 leaves this implementation-defined. If you then call `decoded()`,
+> the lone surrogate is replaced with U+FFFD so the decoded result is always valid
+> UTF-8.
 
 ---
 

--- a/docs/guide/mapping.md
+++ b/docs/guide/mapping.md
@@ -51,6 +51,11 @@ Best for **latency-critical micro-DTOs**. It bypasses the Tape entirely, using *
 User u = qbuem::fuse<User>(json_str);
 ```
 
+> [!NOTE]
+> On invalid input `read<T>` / `fuse<T>` throw [`qbuem::parse_error`](/guide/errors#parse-errors)
+> (a `std::runtime_error` with `offset()`). For [duplicate object keys](/guide/parsing#duplicate-keys),
+> `fuse<T>` is **last-wins** (it overwrites the field) while the DOM `read<T>` is first-wins.
+
 ---
 
 ## 🏗️ Direct Struct Mapping with `QBUEM_JSON_FIELDS`

--- a/docs/guide/parsing.md
+++ b/docs/guide/parsing.md
@@ -55,17 +55,22 @@ while (std::getline(socket_stream, line)) {
 
 ### `qbuem::parse_strict(doc, json)` — RFC 8259 Strict Mode
 
-Throws `std::runtime_error` on any RFC 8259 violation: trailing commas, leading zeros, lone surrogates, etc.
+Throws `qbuem::parse_error` on any RFC 8259 violation — trailing commas, leading zeros, single-quoted strings, trailing garbage — **and** on malformed UTF-8 (overlong encodings, UTF-8-encoded surrogates, code points > U+10FFFF, lone continuation bytes; see [Error Handling](/guide/errors#strict-utf-8-validation)). The relaxed `parse` / `parse_reuse` stay byte-transparent and do not UTF-8-validate.
 
 ```cpp
 try {
     qbuem::Document doc;
     auto root = qbuem::parse_strict(doc, "[1, 2,]"); // throws!
-} catch (const std::runtime_error& e) {
-    // "RFC 8259 violation at offset 6: trailing comma"
-    std::cerr << e.what() << "\n";
+} catch (const qbuem::parse_error& e) {
+    // "RFC 8259 violation at offset 6: trailing comma in array"
+    std::cerr << e.what() << " (byte " << e.offset() << ")\n";
 }
 ```
+
+> [!NOTE]
+> `parse_error` derives from `std::runtime_error` (so old catch blocks still work)
+> and adds `offset()` — the byte position of the failure. It is thrown by every
+> parsing entry point: `parse`, `parse_reuse`, `parse_strict`, `read<T>`, `fuse<T>`.
 
 ### `qbuem::read<T>(json)` — Deserialize via Tape-DOM
 
@@ -104,6 +109,30 @@ bool    active = root["active"].as<bool>();
 // Zero-copy string view (valid as long as doc is alive)
 std::string_view sv = root["tag"].as<std::string_view>();
 ```
+
+### `decoded()` vs raw strings
+
+`as<std::string>()` and `as<std::string_view>()` return the **raw on-the-wire
+bytes** of the string — escape sequences are **not** decoded. This is deliberate:
+the `string_view` form is a zero-copy slice into the document. When you need the
+**logical** value with escapes resolved, call **`decoded()`**:
+
+```cpp
+auto root = qbuem::parse(doc, R"({"path": "C:\\tmp\\a.txt", "emoji": "😀"})");
+
+std::string_view raw = root["path"].as<std::string_view>(); // C:\\tmp\\a.txt  (raw, zero-copy)
+std::string      log = root["path"].decoded();              // C:\tmp\a.txt   (unescaped)
+std::string      em  = root["emoji"].decoded();             // 😀  (surrogate pair → UTF-8)
+```
+
+`decoded()` processes `\" \\ \/ \b \f \n \r \t` and `\uXXXX` (combining surrogate
+pairs into astral code points). A lone/unpaired surrogate becomes **U+FFFD**, so
+`decoded()` output is **always valid UTF-8**.
+
+> [!TIP]
+> Use the raw `as<std::string_view>()` for zero-copy comparisons and forwarding;
+> use `decoded()` whenever the bytes are shown to a user, written to a non-JSON
+> sink, or compared against a decoded value.
 
 ### Implicit Conversion (Ergonomic Shorthand)
 
@@ -216,6 +245,20 @@ int    timeout = root.value("timeout", 5000);
 double ratio   = root.value("ratio", 1.0);
 std::string mode = root.value("mode", std::string{"default"});
 ```
+
+### Duplicate keys
+
+RFC 8259 says object names *should* (not *must*) be unique, so duplicates are
+valid JSON and both engines accept them. The resolution is **deterministic but
+differs by engine**:
+
+| Engine | API | Duplicate resolution |
+| :--- | :--- | :--- |
+| DOM | `root["k"]`, `read<T>` | **first**-wins (returns the first occurrence) |
+| Nexus | `fuse<T>` | **last**-wins (overwrites the field, matching JS/Python/Go) |
+
+If duplicate keys carry security meaning in untrusted input, reject or
+canonicalize upstream — do not rely on cross-engine agreement.
 
 ---
 


### PR DESCRIPTION
## Summary

Updates the user-facing documentation and GitHub Pages content to reflect the wave 1–3 hardening (#118/#119/#120). The `docs.yml` workflow rebuilds VitePress + Doxygen from these sources and force-pushes to `gh-pages` on merge to `main`, so this PR is the source change; the live site updates automatically.

A docs-staleness survey found four features documented **nowhere** (`parse_error`, `decoded()`, strict UTF-8 validation, duplicate-key semantics) plus two stale facts (API ref said v1.0.5; test badge said 521). One existing doc claim was also **wrong** and is corrected.

## Changes

**Guide pages** (`docs/guide/`)
- **errors.md** — parse failures throw the typed `qbuem::parse_error` (a `std::runtime_error` subclass) with `offset()`; new **Strict UTF-8 validation** section. **Bug fix:** the rejected-inputs table claimed a lone-surrogate `\uXXXX` *escape* is rejected — it is actually *accepted* (RFC implementation-defined; verified empirically). Replaced with the real rejections (malformed UTF-8 *bytes*: overlong / surrogate / lone-continuation).
- **parsing.md** — `parse_strict` throws `parse_error` + UTF-8 validation note; new **`decoded()` vs raw strings** section; new **Duplicate keys** table (DOM first-wins, Nexus last-wins).
- **correctness.md** — new **UTF-8 well-formedness (RFC 8259 §8.1)** and **Duplicate object keys** subsections.
- **mapping.md** — `read<T>`/`fuse<T>` throw `parse_error`; `fuse<T>` is last-wins on duplicate keys.

**API reference + meta**
- **api/index.md** — version **v1.0.5 → v1.0.7**; `parse_strict`/`validate` document `parse_error`; new **`parse_error`** and **`decoded()`** entries.
- **README.md** — test badge **521 → 558**; new "Hardened for untrusted input" feature bullet.
- **SECURITY.md** — detailed hardening posture (depth caps, >4 GiB reject, compile-time UAF guard, Nexus field-spoofing verification, strict UTF-8, typed `parse_error`); **"Three" → eleven** libFuzzer targets; sanitizers across x86_64 / aarch64 / Apple Silicon.
- **config.mts** — structured-data test count **521 → 558**.

## Verification
- `npm run docs:build` passes (exit 0, **no dead links** — the new cross-page anchors all resolve; VitePress only ignores `/api/reference/`).
- Windows remains documented as unsupported (already correct in the config FAQ + `operatingSystem: 'Linux, macOS'`).

## Note (pre-existing, out of scope)
`docs/guide/debugging.md` emits a non-fatal `ReferenceError: computed is not defined` during SSR (a missing Vue import, unrelated to these changes — that file is untouched here). The build still exits 0. Happy to fix it in a follow-up if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
