### PR TITLE
chore: bump version to v1.0.8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Existing Korean comments in legacy files should be translated to English when to
 
 ## Project Overview
 
-**qbuem-json v1.0.7** — Single-header C++20 JSON library.
+**qbuem-json v1.0.8** — Single-header C++20 JSON library.
 RFC 8259 compliant, IEEE 754 round-trip, zero external dependencies.
 
 - **Single header**: `include/qbuem_json/qbuem_json.hpp` — ALL logic lives here

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(qbuem_json VERSION 1.0.7 LANGUAGES CXX)
+project(qbuem_json VERSION 1.0.8 LANGUAGES CXX)
 
 # Library Target
 add_library(qbuem_json INTERFACE)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
   <!-- Distribution -->
   <p>
-    <a href="https://github.com/qbuem/qbuem-json/releases/tag/v1.0.7"><img src="https://img.shields.io/badge/version-v1.0.7-blue" alt="v1.0.7"></a>
+    <a href="https://github.com/qbuem/qbuem-json/releases/tag/v1.0.8"><img src="https://img.shields.io/badge/version-v1.0.8-blue" alt="v1.0.8"></a>
     <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="Apache 2.0"></a>
     <a href="https://github.com/qbuem/qbuem-json/blob/main/include/qbuem_json/qbuem_json.hpp"><img src="https://img.shields.io/badge/header--only-single%20file-lightgrey" alt="header-only"></a>
     <img src="https://img.shields.io/badge/dependencies-zero-brightgreen" alt="zero dependencies">

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "qbuem-json"
-version = "1.0.7"
+version = "1.0.8"
 description = "High-performance C++20 JSON parser bindings for Python"
 readme = "../../README.md"
 requires-python = ">=3.8"

--- a/bindings/rust/Cargo.toml
+++ b/bindings/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qbuem-json"
-version = "1.0.7"
+version = "1.0.8"
 edition = "2021"
 authors = ["The Qbuem Team"]
 description = "High-performance C++20 JSON parser bindings (DOM & Mapping) for Rust"

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -179,10 +179,10 @@ export default withMermaid(
                         applicationCategory: 'DeveloperApplication',
                         applicationSubCategory: 'C++ Library',
                         operatingSystem: 'Linux, macOS',
-                        version: '1.0.7',
-                        softwareVersion: '1.0.7',
-                        releaseNotes: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.0.7',
-                        downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.0.7',
+                        version: '1.0.8',
+                        softwareVersion: '1.0.8',
+                        releaseNotes: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.0.8',
+                        downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.0.8',
                         installUrl: 'https://qbuem.com/qbuem-json/guide/getting-started',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
                         keywords: 'C++ JSON library, C++20 JSON, fastest JSON parser, SIMD JSON, AVX-512 JSON, zero-allocation JSON, high-performance JSON, HFT JSON, JSON serializer, single header JSON, header-only JSON, nlohmann alternative, simdjson alternative, RapidJSON alternative',
@@ -230,7 +230,7 @@ export default withMermaid(
                         },
                         runtimePlatform: 'C++20',
                         targetProduct: { '@id': 'https://qbuem.com/qbuem-json/#application' },
-                        version: '1.0.7',
+                        version: '1.0.8',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
                         keywords: 'C++, JSON, SIMD, AVX-512, High-Performance, HFT, parser, serializer, zero-allocation',
                         author: { '@id': 'https://qbuem.com/#organization' }
@@ -377,9 +377,9 @@ export default withMermaid(
                     ]
                 },
                 {
-                    text: 'v1.0.7',
+                    text: 'v1.0.8',
                     items: [
-                        { text: 'Release Notes', link: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.0.7' },
+                        { text: 'Release Notes', link: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.0.8' },
                         { text: 'All Releases', link: 'https://github.com/qbuem/qbuem-json/releases' }
                     ]
                 }

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,6 +1,6 @@
 # API Reference
 
-A complete reference for all public APIs in qbuem-json v1.0.7.
+A complete reference for all public APIs in qbuem-json v1.0.8.
 
 > [!TIP]
 > Looking for auto-generated class/struct documentation? The **[Doxygen Reference](/qbuem-json/api/reference/index.html)** is rebuilt automatically whenever `qbuem_json.hpp` changes and deployed to Pages alongside this guide.

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,7 +76,7 @@ features:
   <!-- Row 4: Package -->
   <div style="display: flex; align-items: center; gap: 0.4rem; flex-wrap: wrap;">
     <span style="font-size: 0.68rem; font-weight: 700; letter-spacing: 0.07em; text-transform: uppercase; color: #999; min-width: 5.5rem; flex-shrink: 0;">Package</span>
-    <a href="https://github.com/qbuem/qbuem-json/releases/tag/v1.0.7"><img src="https://img.shields.io/badge/version-v1.0.7-blue" alt="v1.0.7" /></a>
+    <a href="https://github.com/qbuem/qbuem-json/releases/tag/v1.0.8"><img src="https://img.shields.io/badge/version-v1.0.8-blue" alt="v1.0.8" /></a>
     <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="Apache 2.0" /></a>
     <a href="https://github.com/qbuem/qbuem-json/blob/main/include/qbuem_json/qbuem_json.hpp"><img src="https://img.shields.io/badge/header--only-single%20file-lightgrey" alt="header-only" /></a>
     <img src="https://img.shields.io/badge/dependencies-zero-brightgreen" alt="zero dependencies" />
@@ -183,7 +183,7 @@ Choose the DOM engine when key names are dynamic or unknown at compile time. Swi
 include(FetchContent)
 FetchContent_Declare(qbuem_json
     GIT_REPOSITORY https://github.com/qbuem/qbuem-json.git
-    GIT_TAG        v1.0.7
+    GIT_TAG        v1.0.8
 )
 FetchContent_MakeAvailable(qbuem_json)
 target_link_libraries(my_target PRIVATE qbuem_json::qbuem_json)

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -3,7 +3,7 @@
 > qbuem-json is a high-performance, header-only C++20 JSON library with dual-engine architecture.
 > GitHub: https://github.com/qbuem/qbuem-json
 > Docs: https://qbuem.com/qbuem-json/
-> Version: 1.0.7 · License: Apache 2.0
+> Version: 1.0.8 · License: Apache 2.0
 
 ---
 
@@ -44,7 +44,7 @@ include(FetchContent)
 FetchContent_Declare(
     qbuem_json
     GIT_REPOSITORY https://github.com/qbuem/qbuem-json
-    GIT_TAG        v1.0.7
+    GIT_TAG        v1.0.8
 )
 FetchContent_MakeAvailable(qbuem_json)
 target_link_libraries(your_target PRIVATE qbuem_json::qbuem_json)

--- a/fuzz/fuzz_pmr.cpp
+++ b/fuzz/fuzz_pmr.cpp
@@ -29,7 +29,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
     try {
         // qbuem-json uses std::pmr::string and std::pmr::vector internally if configured
-        // In the v1.0.7 header, we need to ensure we use the PMR versions of Document/Value if available.
+        // In the v1.0.8 header, we need to ensure we use the PMR versions of Document/Value if available.
         // For this fuzzer, we primarily stress the parser's allocation with the chosen resource.
         
         static DocumentView doc; // Note: Current DocumentView might not support custom PMR easily without header changes.

--- a/include/qbuem_json/qbuem_json.hpp
+++ b/include/qbuem_json/qbuem_json.hpp
@@ -1,6 +1,6 @@
 /**
- * @brief qbuem-json v1.0.7 - High-Performance C++20 JSON Parser
- * @version 1.0.7
+ * @brief qbuem-json v1.0.8 - High-Performance C++20 JSON Parser
+ * @version 1.0.8
  *
  * 🏆 Ultimate C++20 JSON Library - 100% Complete!
  *


### PR DESCRIPTION
Bumps the library version v1.0.7 → **v1.0.8** for the next release, covering the wave 1–3 untrusted-input hardening + docs refresh (#118–#121).

Updated: header `@version`, CMake project version, CLAUDE.md, README + docs badges & FetchContent `GIT_TAG`, VitePress structured-data/nav version, `llms-full.txt`, and the Rust/Python binding package versions. Benchmark-fixture `version` payloads and the internal docs-site npm version are intentionally left.

After merge, pushing the `v1.0.8` tag triggers `release.yml` to publish the GitHub Release (auto-generated notes + header + checksums).

🤖 Generated with [Claude Code](https://claude.com/claude-code)