### PR TITLE
feat: CBOR (RFC 8949) binary codec — encode + decode

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -62,7 +62,7 @@ jobs:
         mkdir -p artifacts
         status=0
         for t in fuzz_parse fuzz_dom fuzz_nexus fuzz_direct fuzz_pmr \
-                 fuzz_patch fuzz_api_stress fuzz_rfc8259 fuzz_float; do
+                 fuzz_patch fuzz_api_stress fuzz_rfc8259 fuzz_float fuzz_cbor; do
           echo "::group::$t (${SECS}s)"
           if ! ./build-fuzz/fuzz/$t fuzz/corpus -dict=fuzz/json.dict \
                  -max_len=65536 -rss_limit_mb=4096 -max_total_time=$SECS \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,13 +15,14 @@ Existing Korean comments in legacy files should be translated to English when to
 
 ## Project Overview
 
-**qbuem-json v1.0.8** — Single-header C++20 JSON library.
+**qbuem-json v1.1.0** — Single-header C++20 JSON library.
 RFC 8259 compliant, IEEE 754 round-trip, zero external dependencies.
 
 - **Single header**: `include/qbuem_json/qbuem_json.hpp` — ALL logic lives here
 - **Standard**: C++20 (`target_compile_features(cxx_std_20)`)
 - **No external deps**: header-only INTERFACE library
 - **Integration**: `QBUEM_JSON_FIELDS(Struct, field1, field2, ...)` macro + `qbuem::read<T>()` / `qbuem::write()`
+- **CBOR (RFC 8949)**: the same `QBUEM_JSON_FIELDS` list also drives `qbuem::cbor::encode<T>()` / `qbuem::cbor::decode<T>()` — compact binary that decodes in any language (e.g. JS `cbor-x`). Register fields once; serialize to both JSON and CBOR.
 
 ---
 
@@ -121,6 +122,12 @@ Child c = *result;
 auto body_sv = std::string_view{
     reinterpret_cast<const char*>(body.data()), body.size()};
 auto child_r = qbuem::read<Child>(body_sv);
+
+// 5. CBOR binary (RFC 8949) — same field list, no extra registration
+std::string bytes = qbuem::cbor::encode(child);          // → compact binary
+Child       back  = qbuem::cbor::decode<Child>(bytes);   // ← throws parse_error on bad input
+// decode<T> accepts a string_view OR (const uint8_t*, size_t); trailing bytes
+// after the top-level item are ignored (framed-message friendly).
 ```
 
 ---

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(qbuem_json VERSION 1.0.8 LANGUAGES CXX)
+project(qbuem_json VERSION 1.1.0 LANGUAGES CXX)
 
 # Library Target
 add_library(qbuem_json INTERFACE)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ QBUEM_JSON_FIELDS(Player, name, score)  // must be outside the struct, at namesp
 
 auto player = qbuem::fuse<Player>(R"({"name":"Bob","score":99})");
 std::string json = qbuem::write(player);
+
+// ── CBOR binary codec (RFC 8949) — same field list, compact bytes ────
+std::string bytes  = qbuem::cbor::encode(player);          // → CBOR
+Player      back   = qbuem::cbor::decode<Player>(bytes);   // ← CBOR
+// The bytes decode in any language too (e.g. JS `cbor-x`) — no shared schema.
 ```
 
 ---
@@ -87,8 +92,9 @@ std::string json = qbuem::write(player);
 * **Zero-Allocation Execution** — Sequential memory layout and zero-copy strings for deterministic performance.
 * **Single Header** — Drop `qbuem_json.hpp` into your project and you're ready. Zero external dependencies.
 * **STL Support** — `std::vector`, `std::map`, `std::optional`, `std::tuple`, `std::variant` and more work out of the box.
+* **CBOR Codec (RFC 8949)** — `qbuem::cbor::encode<T>()` / `decode<T>()` reuse the same `QBUEM_JSON_FIELDS` list to produce compact, self-describing binary. Cross-language by design: the bytes decode in any RFC 8949 reader (e.g. JavaScript `cbor-x`) with no shared schema, and the decoder is bounds-checked + fuzzed for untrusted network input.
 * **Three-stage float parsing** — Eisel-Lemire (~98.8 %) → Russ Cox Unrounded Scaling (~1.2 %) → `std::strtod` (subnormals only). `parse(serialize(x)) == x` for all finite doubles.
-* **Hardened for untrusted input** — strict mode validates UTF-8 well-formedness (rejects overlong / surrogate / truncated sequences, RFC 8259 §8.1); parse failures throw a typed `qbuem::parse_error` with `offset()`; zero-copy use-after-free misuse is a **compile error**. Continuously fuzzed (11 libFuzzer targets) and sanitized (ASan/UBSan/TSan across x86_64 / aarch64 / Apple Silicon).
+* **Hardened for untrusted input** — strict mode validates UTF-8 well-formedness (rejects overlong / surrogate / truncated sequences, RFC 8259 §8.1); parse failures throw a typed `qbuem::parse_error` with `offset()`; zero-copy use-after-free misuse is a **compile error**. Continuously fuzzed (12 libFuzzer targets) and sanitized (ASan/UBSan/TSan across x86_64 / aarch64 / Apple Silicon).
 
 ---
 

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -61,3 +61,4 @@ add_fuzz_target(fuzz_direct)     # DirectParser & Key mapping stress test
 add_fuzz_target(fuzz_diff nlohmann_json::nlohmann_json) # Differential testing vs nlohmann/json
 add_fuzz_target(fuzz_pmr)        # PMR allocator stress test
 add_fuzz_target(fuzz_patch)      # JSON Pointer & Mutation stress test
+add_fuzz_target(fuzz_cbor)       # CBOR codec: decode hostile bytes + round-trip

--- a/fuzz/fuzz_cbor.cpp
+++ b/fuzz/fuzz_cbor.cpp
@@ -1,0 +1,64 @@
+// fuzz_cbor — CBOR codec stress test.
+//
+// Two angles, both must never read out of bounds, hang, or trip UBSan:
+//   1. decode arbitrary bytes      → cbor::decode<T>(raw fuzzer input)
+//   2. encode → decode round-trip  → decode succeeds ⇒ re-encode ⇒ re-decode
+// The first proves the reader is hostile-input safe (truncation, bogus heads,
+// length bombs, deep nesting); the second proves the encoder always emits bytes
+// the decoder accepts (self-consistency).
+#include <qbuem_json/qbuem_json.hpp>
+
+#include <array>
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <vector>
+
+struct CborNested {
+  int64_t id;
+  std::string name;
+};
+QBUEM_JSON_FIELDS(CborNested, id, name)
+
+struct CborFuzz {
+  int64_t i;
+  uint64_t u;
+  double d;
+  bool b;
+  std::string s;
+  std::vector<int64_t> v;
+  std::optional<std::string> o;
+  std::map<std::string, int64_t> m;
+  std::array<int64_t, 3> arr;
+  std::pair<std::string, double> pr;
+  CborNested nested;
+};
+QBUEM_JSON_FIELDS(CborFuzz, i, u, d, b, s, v, o, m, arr, pr, nested)
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  const std::string_view input(reinterpret_cast<const char *>(data), size);
+
+  // 1. Decode hostile bytes — must throw or partially decode, never read OOB.
+  try {
+    CborFuzz obj = qbuem::cbor::decode<CborFuzz>(input);
+
+    // 2. Anything that decoded must re-encode and re-decode cleanly.
+    std::string encoded = qbuem::cbor::encode(obj);
+    try {
+      (void)qbuem::cbor::decode<CborFuzz>(encoded);
+    } catch (...) {
+    }
+  } catch (const std::exception &) {
+    // Expected for malformed CBOR.
+  }
+
+  // 3. The (ptr,len) overload shares the path but exercises a different entry.
+  try {
+    (void)qbuem::cbor::decode<CborFuzz>(data, size);
+  } catch (...) {
+  }
+
+  return 0;
+}

--- a/include/qbuem_json/qbuem_json.hpp
+++ b/include/qbuem_json/qbuem_json.hpp
@@ -1,6 +1,6 @@
 /**
- * @brief qbuem-json v1.0.8 - High-Performance C++20 JSON Parser
- * @version 1.0.8
+ * @brief qbuem-json v1.1.0 - High-Performance C++20 JSON Parser
+ * @version 1.1.0
  *
  * 🏆 Ultimate C++20 JSON Library - 100% Complete!
  *
@@ -16,6 +16,9 @@
  * ✅ Russ Cox: Fast Unrounded Scaling — 2nd-stage float parser (Cox 2026).
  * ✅ Full SIMD: AVX-512, NEON, and SWAR structural indexing.
  * ✅ C++20 Native: Concepts, Ranges, and std::pmr support.
+ * ✅ CBOR codec (RFC 8949): qbuem::cbor::encode/decode — the same
+ *    QBUEM_JSON_FIELDS list serializes to compact binary that any RFC 8949
+ *    decoder (e.g. JS cbor-x) reads without a shared schema.
  *
  * Documentation: https://qbuem.com/qbuem-json/
  *
@@ -8683,6 +8686,381 @@ template <typename T> void append_json(std::string &out, const T &in) {
   append_json<std::string, T>(out, in);
 }
 
+// ── CBOR (RFC 8259's binary sibling, RFC 8949) ───────────────────────────────
+// A binary serialization backend that mirrors append_json<W,T> 1:1 and reuses
+// the SAME type concepts, so any QBUEM_JSON_FIELDS struct serializes to CBOR with
+// no extra per-struct code. Self-describing → any language decodes it (e.g. the
+// JS `cbor-x` library) without a shared schema. Output goes through the same
+// W writer abstraction (json_put / json_write) used by the JSON path.
+
+// Forward declaration for nested-struct dispatch (defined by QBUEM_JSON_FIELDS).
+template <typename T, typename W>
+concept HasQbuemJsonAppendCbor = requires(W &w, const T &t) {
+  qbuem_json_append_cbor(w, t);
+};
+
+// Write a CBOR data-item head: major type (0..7) + argument, smallest encoding.
+template <typename W>
+QBUEM_INLINE void cbor_head(W &out, uint8_t major, uint64_t val) {
+  const auto mt = static_cast<uint8_t>(major << 5);
+  if (val < 24u) {
+    json_put(out, static_cast<char>(mt | static_cast<uint8_t>(val)));
+  } else if (val <= 0xffull) {
+    json_put(out, static_cast<char>(mt | 24));
+    json_put(out, static_cast<char>(val));
+  } else if (val <= 0xffffull) {
+    json_put(out, static_cast<char>(mt | 25));
+    json_put(out, static_cast<char>(val >> 8));
+    json_put(out, static_cast<char>(val));
+  } else if (val <= 0xffffffffull) {
+    json_put(out, static_cast<char>(mt | 26));
+    for (int s = 24; s >= 0; s -= 8) json_put(out, static_cast<char>(val >> s));
+  } else {
+    json_put(out, static_cast<char>(mt | 27));
+    for (int s = 56; s >= 0; s -= 8) json_put(out, static_cast<char>(val >> s));
+  }
+}
+
+template <typename W, typename Tup, size_t... I>
+void append_cbor_tuple_(W &out, const Tup &in, std::index_sequence<I...>);
+
+template <typename W, typename T> void append_cbor(W &out, const T &in) {
+  if constexpr (std::is_same_v<T, std::nullptr_t>) {
+    json_put(out, static_cast<char>(0xf6)); // null
+  } else if constexpr (JsonDetailBool<T>) {
+    json_put(out, static_cast<char>(in ? 0xf5 : 0xf4)); // true / false
+  } else if constexpr (std::is_integral_v<T>) {
+    if constexpr (std::is_unsigned_v<T>) {
+      cbor_head(out, 0, static_cast<uint64_t>(in));
+    } else {
+      const int64_t v = static_cast<int64_t>(in);
+      if (v < 0) cbor_head(out, 1, static_cast<uint64_t>(-1 - v)); // negative
+      else       cbor_head(out, 0, static_cast<uint64_t>(v));
+    }
+  } else if constexpr (std::is_floating_point_v<T>) {
+    // IEEE-754 double, big-endian (major 7, additional info 27).
+    const double d = static_cast<double>(in);
+    uint64_t bits;
+    std::memcpy(&bits, &d, 8);
+    json_put(out, static_cast<char>(0xfb));
+    for (int s = 56; s >= 0; s -= 8) json_put(out, static_cast<char>(bits >> s));
+  } else if constexpr (std::is_same_v<T, std::string> ||
+                       std::is_same_v<T, std::string_view>) {
+    cbor_head(out, 3, in.size()); // text string
+    json_write(out, in.data(), in.size());
+  } else if constexpr (std::is_same_v<T, const char *>) {
+    const std::string_view sv(in ? in : "");
+    cbor_head(out, 3, sv.size());
+    json_write(out, sv.data(), sv.size());
+  } else if constexpr (JsonDetailOptional<T>) {
+    if (!in.has_value()) json_put(out, static_cast<char>(0xf6));
+    else append_cbor(out, *in);
+  } else if constexpr (JsonDetailSeq<T> || JsonDetailSet<T>) {
+    if constexpr (requires { in.size(); }) {
+      cbor_head(out, 4, in.size());                  // definite-length array
+      for (const auto &item : in) append_cbor(out, item);
+    } else {
+      json_put(out, static_cast<char>(0x9f));        // indefinite-length array
+      for (const auto &item : in) append_cbor(out, item);
+      json_put(out, static_cast<char>(0xff));        // break
+    }
+  } else if constexpr (JsonDetailMap<T>) {
+    cbor_head(out, 5, in.size());
+    for (const auto &[k, val] : in) { append_cbor(out, k); append_cbor(out, val); }
+  } else if constexpr (JsonDetailFixedArr<T>) {
+    constexpr size_t N = std::tuple_size_v<T>;
+    cbor_head(out, 4, N);
+    for (size_t i = 0; i < N; ++i) append_cbor(out, in[i]);
+  } else if constexpr (JsonDetailTuple<T>) {
+    constexpr size_t N = std::tuple_size_v<T>;
+    cbor_head(out, 4, N);
+    append_cbor_tuple_(out, in, std::make_index_sequence<N>{});
+  } else if constexpr (HasQbuemJsonAppendCbor<T, W>) {
+    qbuem_json_append_cbor(out, in); // nested struct (generated by the macro)
+  } else {
+    static_assert(sizeof(T) == 0,
+                  "qbuem::cbor::encode / append_cbor: no serialization for T. "
+                  "Use QBUEM_JSON_FIELDS(Type, field...).");
+  }
+}
+
+template <typename W, typename Tup, size_t... I>
+void append_cbor_tuple_(W &out, const Tup &in, std::index_sequence<I...>) {
+  (append_cbor(out, std::get<I>(in)), ...);
+}
+
+template <typename T> void append_cbor(std::string &out, const T &in) {
+  append_cbor<std::string, T>(out, in);
+}
+
+// ── CBOR decode ──────────────────────────────────────────────────────────────
+// Type-driven reader: the target C++ type dictates which CBOR data item is
+// expected (the inverse of append_cbor). Mirrors the from_json dispatch order so
+// any QBUEM_JSON_FIELDS struct round-trips JSON ⇄ CBOR through one field list.
+// Reads anything cbor-x / any RFC 8949 encoder emits: definite OR indefinite
+// arrays/maps, half/single/double floats, smallest-int encodings. Strings are
+// zero-copy views into the input buffer. Every advance is bounds-checked, so a
+// truncated or hostile payload throws parse_error rather than reading OOB.
+
+// Sentinel returned by read_*_header() for an indefinite-length item (0x9f/0xbf).
+inline constexpr size_t kCborIndef = static_cast<size_t>(-1);
+
+inline int &nexus_depth() noexcept; // defined below; shared recursion counter
+// Bounds CBOR nesting to the same depth as the typed JSON path (fuzz safety:
+// a recursive schema fed deeply-nested arrays/maps would otherwise blow the
+// native stack). Only the array/map/optional/struct branches construct it.
+struct CborDepthGuard {
+  CborDepthGuard() {
+    if (++nexus_depth() > 1024) {
+      --nexus_depth();
+      throw ::std::runtime_error("CBOR: input nesting too deep");
+    }
+  }
+  ~CborDepthGuard() { --nexus_depth(); }
+};
+
+// IEEE-754 binary16 → double (CBOR major 7 / 0xf9).
+QBUEM_INLINE double cbor_half_to_double(uint16_t h) noexcept {
+  const uint16_t exp = (h >> 10) & 0x1f;
+  const uint16_t mant = h & 0x3ff;
+  double val;
+  if (exp == 0)
+    val = ::std::ldexp(static_cast<double>(mant), -24);
+  else if (exp != 31)
+    val = ::std::ldexp(static_cast<double>(mant + 1024), exp - 25);
+  else
+    val = (mant == 0) ? ::std::numeric_limits<double>::infinity()
+                      : ::std::numeric_limits<double>::quiet_NaN();
+  return (h & 0x8000) ? -val : val;
+}
+
+struct CborReader {
+  const uint8_t *p;
+  const uint8_t *begin;
+  const uint8_t *end;
+
+  CborReader(const char *data, size_t n) noexcept
+      : p(reinterpret_cast<const uint8_t *>(data)), begin(p), end(p + n) {}
+
+  [[noreturn]] void fail(const char *msg) const {
+    throw_parse_error(
+        msg, reinterpret_cast<const char *>(p),
+        ::std::string_view(reinterpret_cast<const char *>(begin),
+                           static_cast<size_t>(end - begin)));
+  }
+  // Guarantee at least n more bytes; otherwise the payload is truncated.
+  void need(size_t n) const {
+    if (static_cast<size_t>(end - p) < n) fail("CBOR: truncated input");
+  }
+
+  // Read an initial byte + its finite argument; sets mt to the major type.
+  // Rejects additional-info 28..31 (reserved / indefinite — handled by the
+  // header readers, never as a plain argument).
+  uint64_t read_head(uint8_t &mt) {
+    need(1);
+    const uint8_t ib = *p++;
+    mt = static_cast<uint8_t>(ib >> 5);
+    const uint8_t ai = ib & 31;
+    if (ai < 24) return ai;
+    if (ai == 24) { need(1); return *p++; }
+    if (ai == 25) { need(2); uint64_t v = (uint64_t(p[0]) << 8) | p[1]; p += 2; return v; }
+    if (ai == 26) { need(4); uint64_t v = 0; for (int i = 0; i < 4; ++i) v = (v << 8) | *p++; return v; }
+    if (ai == 27) { need(8); uint64_t v = 0; for (int i = 0; i < 8; ++i) v = (v << 8) | *p++; return v; }
+    fail("CBOR: reserved/indefinite additional-info");
+  }
+
+  bool read_bool() {
+    need(1);
+    const uint8_t ib = *p;
+    if (ib == 0xf5) { ++p; return true; }
+    if (ib == 0xf4) { ++p; return false; }
+    fail("CBOR: expected bool");
+  }
+  bool try_read_null() {
+    need(1);
+    // Treat both null (0xf6) and undefined (0xf7) as "absent".
+    if (*p == 0xf6 || *p == 0xf7) { ++p; return true; }
+    return false;
+  }
+  void read_null() { if (!try_read_null()) fail("CBOR: expected null"); }
+
+  double read_float() {
+    need(1);
+    const uint8_t ib = *p;
+    if (ib == 0xfb) {
+      need(9); ++p; uint64_t b = 0;
+      for (int i = 0; i < 8; ++i) b = (b << 8) | *p++;
+      double d; ::std::memcpy(&d, &b, 8); return d;
+    }
+    if (ib == 0xfa) {
+      need(5); ++p; uint32_t b = 0;
+      for (int i = 0; i < 4; ++i) b = (b << 8) | *p++;
+      float f; ::std::memcpy(&f, &b, 4); return static_cast<double>(f);
+    }
+    if (ib == 0xf9) {
+      need(3); ++p; uint16_t h = static_cast<uint16_t>((uint16_t(p[0]) << 8) | p[1]);
+      p += 2; return cbor_half_to_double(h);
+    }
+    // Lenient: accept an integer where a float is expected (cbor-x emits whole
+    // numbers as ints), so {score: 3} decodes into a double field.
+    uint8_t mt; uint64_t arg = read_head(mt);
+    if (mt == 0) return static_cast<double>(arg);
+    if (mt == 1) return -1.0 - static_cast<double>(arg);
+    fail("CBOR: expected float or integer");
+  }
+
+  ::std::string_view read_text() {
+    uint8_t mt; uint64_t n = read_head(mt);
+    if (mt != 3) fail("CBOR: expected text string");
+    need(static_cast<size_t>(n));
+    const char *s = reinterpret_cast<const char *>(p);
+    p += n;
+    return ::std::string_view(s, static_cast<size_t>(n));
+  }
+
+  // Open an array/map. Returns the entry count, or kCborIndef for 0x9f/0xbf.
+  size_t read_array_header() {
+    need(1);
+    if (*p == 0x9f) { ++p; return kCborIndef; }
+    uint8_t mt; uint64_t n = read_head(mt);
+    if (mt != 4) fail("CBOR: expected array");
+    return static_cast<size_t>(n);
+  }
+  size_t read_map_header() {
+    need(1);
+    if (*p == 0xbf) { ++p; return kCborIndef; }
+    uint8_t mt; uint64_t n = read_head(mt);
+    if (mt != 5) fail("CBOR: expected map");
+    return static_cast<size_t>(n);
+  }
+  // For indefinite items: true while more entries remain (i.e. not at break).
+  bool peek_break() { need(1); return *p == 0xff; }
+  void consume_break() {
+    need(1);
+    if (*p != 0xff) fail("CBOR: expected break");
+    ++p;
+  }
+};
+
+// Skip exactly one complete CBOR data item (used for unknown map keys and
+// over-long fixed-size targets). Recursion is depth-bounded via CborDepthGuard.
+inline void cbor_skip(CborReader &cr) {
+  cr.need(1);
+  const uint8_t ib = *cr.p;
+  const uint8_t mt = static_cast<uint8_t>(ib >> 5);
+  const uint8_t ai = ib & 31;
+  if (ai == 31 && mt >= 2 && mt <= 5) { // indefinite array/map/byte/text string
+    ++cr.p;
+    CborDepthGuard g;
+    while (!cr.peek_break()) {
+      cbor_skip(cr);
+      if (mt == 5) cbor_skip(cr); // map: skip the value too
+    }
+    cr.consume_break();
+    return;
+  }
+  uint8_t m; uint64_t arg = cr.read_head(m);
+  switch (m) {
+    case 0: case 1: case 7: break; // int / float / simple — arg already consumed
+    case 2: case 3:                // byte / text string payload
+      cr.need(static_cast<size_t>(arg));
+      cr.p += arg;
+      break;
+    case 4: { CborDepthGuard g; for (uint64_t i = 0; i < arg; ++i) cbor_skip(cr); break; }
+    case 5: { CborDepthGuard g; for (uint64_t i = 0; i < arg; ++i) { cbor_skip(cr); cbor_skip(cr); } break; }
+    default: cr.fail("CBOR: unsupported major type");
+  }
+}
+
+template <typename T> void from_cbor(CborReader &cr, T &out);
+
+// ADL hook generated by QBUEM_JSON_FIELDS (decodes a CBOR map into the struct).
+template <typename T>
+concept HasQbuemJsonReadCbor =
+    requires(CborReader &cr, T &t) { qbuem_json_read_cbor(cr, t); };
+
+template <typename T, size_t... I>
+void from_cbor_tuple_(CborReader &cr, T &out, std::index_sequence<I...>) {
+  (from_cbor(cr, std::get<I>(out)), ...);
+}
+
+template <typename T> void from_cbor(CborReader &cr, T &out) {
+  if constexpr (std::is_same_v<T, std::nullptr_t>) {
+    cr.read_null();
+  } else if constexpr (JsonDetailBool<T>) {
+    out = cr.read_bool();
+  } else if constexpr (std::is_integral_v<T>) {
+    uint8_t mt; uint64_t arg = cr.read_head(mt);
+    if (mt == 0)      out = static_cast<T>(arg);               // unsigned: exact
+    else if (mt == 1) out = static_cast<T>(-1 - static_cast<int64_t>(arg));
+    else              cr.fail("CBOR: expected integer");
+  } else if constexpr (std::is_floating_point_v<T>) {
+    out = static_cast<T>(cr.read_float());
+  } else if constexpr (std::is_same_v<T, std::string>) {
+    out.assign(cr.read_text());
+  } else if constexpr (JsonDetailOptional<T>) {
+    if (cr.try_read_null()) { out = std::nullopt; return; }
+    CborDepthGuard g;
+    typename T::value_type inner{};
+    from_cbor(cr, inner);
+    out = std::move(inner);
+  } else if constexpr (JsonDetailSeq<T> || JsonDetailSet<T>) {
+    CborDepthGuard g;
+    out.clear();
+    const size_t n = cr.read_array_header();
+    auto take = [&] {
+      typename T::value_type item{};
+      from_cbor(cr, item);
+      if constexpr (JsonDetailSeq<T>) out.push_back(std::move(item));
+      else                            out.insert(std::move(item));
+    };
+    if (n == kCborIndef) { while (!cr.peek_break()) take(); cr.consume_break(); }
+    else { for (size_t i = 0; i < n; ++i) take(); }
+  } else if constexpr (JsonDetailMap<T>) {
+    CborDepthGuard g;
+    out.clear();
+    const size_t n = cr.read_map_header();
+    auto take = [&] {
+      std::string k(cr.read_text());
+      typename T::mapped_type item{};
+      from_cbor(cr, item);
+      out.emplace(std::move(k), std::move(item));
+    };
+    if (n == kCborIndef) { while (!cr.peek_break()) take(); cr.consume_break(); }
+    else { for (size_t i = 0; i < n; ++i) take(); }
+  } else if constexpr (JsonDetailFixedArr<T>) {
+    CborDepthGuard g;
+    constexpr size_t N = std::tuple_size_v<T>;
+    const size_t n = cr.read_array_header();
+    if (n == kCborIndef) {
+      size_t i = 0;
+      while (!cr.peek_break()) {
+        if (i < N) from_cbor(cr, out[i++]); else cbor_skip(cr);
+      }
+      cr.consume_break();
+    } else {
+      for (size_t i = 0; i < n; ++i) {
+        if (i < N) from_cbor(cr, out[i]); else cbor_skip(cr);
+      }
+    }
+  } else if constexpr (JsonDetailTuple<T>) {
+    CborDepthGuard g;
+    constexpr size_t N = std::tuple_size_v<T>;
+    const size_t n = cr.read_array_header();
+    from_cbor_tuple_(cr, out, std::make_index_sequence<N>{});
+    // Drain any extra elements an oversized encoder may have written.
+    if (n == kCborIndef) { while (!cr.peek_break()) cbor_skip(cr); cr.consume_break(); }
+    else { for (size_t i = N; i < n; ++i) cbor_skip(cr); }
+  } else if constexpr (HasQbuemJsonReadCbor<T>) {
+    CborDepthGuard g;
+    qbuem_json_read_cbor(cr, out); // nested struct (generated by the macro)
+  } else {
+    static_assert(sizeof(T) == 0,
+                  "qbuem::cbor::decode / from_cbor: no deserialization for T. "
+                  "Use QBUEM_JSON_FIELDS(Type, field...).");
+  }
+}
+
 // ── Per-field helpers for QBUEM_JSON_FIELDS
 
 template <typename T>
@@ -8788,6 +9166,23 @@ inline void to_json_field(Value &obj, const char *key, const T &val) {
   ::qbuem::json::detail::append_json(_bj_fw, obj.f);                          \
   _bj_fw.put(',');
 
+// QBUEM_JSON_DETAIL_APPEND_CBOR — one CBOR map entry: text key + value
+#define QBUEM_JSON_DETAIL_APPEND_CBOR(f)                                       \
+  ::qbuem::json::detail::append_cbor(_bj_w, ::std::string_view(#f));           \
+  ::qbuem::json::detail::append_cbor(_bj_w, obj.f);
+
+// QBUEM_JSON_DETAIL_CBOR_READ — one switch case routing a CBOR map key to its
+// field.  The hash is collision-prone, so the key bytes are verified before the
+// field is filled (same spoofing defence as the JSON nexus_pulse path); an
+// unmatched key has its value skipped wholesale.
+#define QBUEM_JSON_DETAIL_CBOR_READ(f)                                         \
+  case ::qbuem::json::detail::fast_key_hash_ce(#f):                            \
+    if (_key == ::std::string_view(#f, sizeof(#f) - 1))                        \
+      ::qbuem::json::detail::from_cbor(_cr, obj.f);                            \
+    else                                                                       \
+      ::qbuem::json::detail::cbor_skip(_cr);                                   \
+    break;
+
 #define QBUEM_JSON_FIELDS(Type, ...)                                           \
   /* Fast dispatch on pre-computed key hash — primary hot path */              \
   inline void nexus_pulse_h(uint64_t _h, ::std::string_view _key,             \
@@ -8824,6 +9219,35 @@ inline void to_json_field(Value &obj, const char *key, const T &val) {
   }                                                                            \
   inline void append_qbuem_json(std::string &out, const Type &obj) {           \
     qbuem_json_append_fw(out, obj);                                            \
+  }                                                                            \
+  /* CBOR serialization — indefinite-length map of the registered fields */    \
+  template <typename _W>                                                       \
+  inline void qbuem_json_append_cbor(_W &_bj_w, const Type &obj) {             \
+    ::qbuem::json::detail::json_put(_bj_w, static_cast<char>(0xbf)); /*map(*)*/ \
+    QBUEM_FOR_EACH(QBUEM_JSON_DETAIL_APPEND_CBOR, __VA_ARGS__)                  \
+    ::qbuem::json::detail::json_put(_bj_w, static_cast<char>(0xff)); /*break*/  \
+  }                                                                            \
+  /* CBOR deserialization — reads a map (definite or indefinite), dispatching  \
+     each text key to its field; unknown keys are skipped.  Templated on the    \
+     reader (always CborReader) purely so it is instantiated lazily — only      \
+     structs actually decoded pay the from_cbor type-check, matching the        \
+     append_cbor template above. */                                            \
+  template <typename _R>                                                       \
+  inline void qbuem_json_read_cbor(_R &_cr, Type &obj) {                        \
+    const ::std::size_t _n = _cr.read_map_header();                            \
+    for (::std::size_t _i = 0;                                                  \
+         (_n == ::qbuem::json::detail::kCborIndef) ? !_cr.peek_break()         \
+                                                   : (_i < _n);                 \
+         ++_i) {                                                                \
+      const ::std::string_view _key = _cr.read_text();                         \
+      switch (::qbuem::json::detail::fast_key_hash(_key)) {                     \
+        QBUEM_FOR_EACH(QBUEM_JSON_DETAIL_CBOR_READ, __VA_ARGS__)                \
+      default:                                                                  \
+        ::qbuem::json::detail::cbor_skip(_cr);                                  \
+        break;                                                                  \
+      }                                                                         \
+    }                                                                          \
+    if (_n == ::qbuem::json::detail::kCborIndef) _cr.consume_break();           \
   }
 
 
@@ -9482,6 +9906,49 @@ template <typename T> void from_json(const Value &v, T &out) {
 template <typename T>::std::string to_json_str(const T &val) {
   return ::qbuem::json::detail::to_json_str(val);
 }
+
+// ── CBOR binary serialization (RFC 8949) ─────────────────────────────────────
+// cbor::encode(obj) → compact, self-describing binary that decodes in any
+// language (e.g. the JS `cbor-x` library) without a shared schema. Reuses the
+// QBUEM_JSON_FIELDS field list — register a field once and it serializes to both
+// JSON and CBOR. Bytes are returned in a std::string (a byte container here).
+namespace cbor {
+
+template <typename T> void encode_to(::std::string &buf, const T &obj) {
+  ::qbuem::json::detail::append_cbor(buf, obj);
+}
+
+template <typename T> [[nodiscard]] ::std::string encode(const T &obj) {
+  ::std::string buf;
+  buf.reserve(64);
+  ::qbuem::json::detail::append_cbor(buf, obj);
+  return buf;
+}
+
+// decode<T>(bytes) → T.  Inverse of encode: reads the CBOR data item into a T
+// (any QBUEM_JSON_FIELDS struct or supported STL type).  Throws qbuem::parse_error
+// on a truncated, malformed, or type-mismatched payload — never reads out of
+// bounds, so it is safe on untrusted network input.  Trailing bytes after the
+// top-level item are ignored (framed-message friendly).
+template <typename T> [[nodiscard]] T decode(::std::string_view bytes) {
+  ::qbuem::json::detail::CborReader cr(bytes.data(), bytes.size());
+  T obj{};
+  ::qbuem::json::detail::from_cbor(cr, obj);
+  return obj;
+}
+
+template <typename T>
+[[nodiscard]] T decode(const ::std::uint8_t *data, ::std::size_t n) {
+  return decode<T>(::std::string_view(reinterpret_cast<const char *>(data), n));
+}
+
+// decode_into(bytes, obj) — fill an existing object (reuses its heap capacity).
+template <typename T> void decode_into(::std::string_view bytes, T &obj) {
+  ::qbuem::json::detail::CborReader cr(bytes.data(), bytes.size());
+  ::qbuem::json::detail::from_cbor(cr, obj);
+}
+
+} // namespace cbor
 
 } // namespace qbuem
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,6 +70,7 @@ add_qbuem_gtest(test_utf8_validation)
 add_qbuem_gtest(test_duplicate_keys)
 add_qbuem_gtest(test_serializer)
 add_qbuem_gtest(test_errors)
+add_qbuem_gtest(test_cbor)
 
 # ── New: dom API type coverage and round-trip fidelity ────────────────────
 add_qbuem_gtest(test_dom_types)

--- a/tests/test_cbor.cpp
+++ b/tests/test_cbor.cpp
@@ -1,0 +1,222 @@
+// CBOR encode tests: serialize QBUEM_JSON_FIELDS structs to CBOR and verify the
+// bytes with an independent minimal reference decoder (the encoder must produce
+// valid, correctly-typed RFC 8949 data items).
+#include <gtest/gtest.h>
+
+#include "qbuem_json/qbuem_json.hpp"
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+// ── Minimal reference CBOR reader (independent of the encoder) ────────────────
+namespace {
+struct Rd {
+  const uint8_t *p, *e;
+  uint8_t major() const { return *p >> 5; }
+  uint64_t head() {
+    uint8_t info = *p++ & 31; uint64_t v = info;
+    if (info == 24) v = *p++;
+    else if (info == 25) { v = (uint64_t(p[0]) << 8) | p[1]; p += 2; }
+    else if (info == 26) { v = 0; for (int i = 0; i < 4; ++i) v = (v << 8) | *p++; }
+    else if (info == 27) { v = 0; for (int i = 0; i < 8; ++i) v = (v << 8) | *p++; }
+    return v;
+  }
+  int64_t rd_int() { uint8_t m = major(); uint64_t a = head(); return m == 1 ? -1 - int64_t(a) : int64_t(a); }
+  std::string rd_text() { uint64_t n = head(); std::string s((const char *)p, n); p += n; return s; }
+  double rd_double() { ++p; uint64_t b = 0; for (int i = 0; i < 8; ++i) b = (b << 8) | *p++; double d; std::memcpy(&d, &b, 8); return d; }
+  bool rd_bool() { return (*p++ & 31) == 21; }
+  bool is_null() { if (*p == 0xf6) { ++p; return true; } return false; }
+  bool at_break() const { return *p == 0xff; }
+  void skip_break() { ++p; }
+  bool open_indef_map() { if (*p == 0xbf) { ++p; return true; } return false; }
+  uint64_t open_array() { return head(); }
+};
+
+// ── Minimal reference CBOR *writer* (independent of the encoder) ──────────────
+// Used to forge payloads a different encoder (e.g. JS cbor-x) would emit —
+// definite-length maps/arrays, smallest-int forms, half/single floats — and feed
+// them to qbuem::cbor::decode to prove cross-encoder interop.
+struct Wr {
+  std::string b;
+  void head(uint8_t major, uint64_t v) {
+    uint8_t m = uint8_t(major << 5);
+    if (v < 24) b.push_back(char(m | v));
+    else if (v < 256) { b.push_back(char(m | 24)); b.push_back(char(v)); }
+    else if (v < 65536) { b.push_back(char(m | 25)); b.push_back(char(v >> 8)); b.push_back(char(v)); }
+    else { b.push_back(char(m | 26)); for (int s = 24; s >= 0; s -= 8) b.push_back(char(v >> s)); }
+  }
+  void u(uint64_t v) { head(0, v); }
+  void i(int64_t v) { if (v < 0) head(1, uint64_t(-1 - v)); else head(0, uint64_t(v)); }
+  void str(const std::string &s) { head(3, s.size()); b += s; }
+  void def_map(uint64_t n) { head(5, n); }        // definite-length map
+  void def_arr(uint64_t n) { head(4, n); }        // definite-length array
+  void key(const char *k) { str(k); }
+  void f64(double d) { uint64_t bits; std::memcpy(&bits, &d, 8); b.push_back(char(0xfb)); for (int s = 56; s >= 0; s -= 8) b.push_back(char(bits >> s)); }
+  void f32(float f) { uint32_t bits; std::memcpy(&bits, &f, 4); b.push_back(char(0xfa)); for (int s = 24; s >= 0; s -= 8) b.push_back(char(bits >> s)); }
+  void f16(uint16_t h) { b.push_back(char(0xf9)); b.push_back(char(h >> 8)); b.push_back(char(h)); }
+  void boolean(bool v) { b.push_back(char(v ? 0xf5 : 0xf4)); }
+  void null() { b.push_back(char(0xf6)); }
+};
+
+} // namespace
+
+// NB: QBUEM_JSON_FIELDS must be invoked in the SAME scope as the struct so the
+// generated (de)serializers are found by ADL — true for both JSON and CBOR.
+struct Inner { int64_t a; std::string b; };
+QBUEM_JSON_FIELDS(Inner, a, b)
+
+struct Msg {
+  int64_t id; std::string name; double score; bool active;
+  std::optional<int64_t> opt; std::vector<int64_t> nums; Inner inner;
+};
+QBUEM_JSON_FIELDS(Msg, id, name, score, active, opt, nums, inner)
+
+struct Bag {
+  std::map<std::string, int64_t> dict;
+  std::array<int64_t, 3> trip;
+  std::pair<std::string, int64_t> kv;
+};
+QBUEM_JSON_FIELDS(Bag, dict, trip, kv)
+
+struct U64 { uint64_t big; };
+QBUEM_JSON_FIELDS(U64, big)
+
+TEST(Cbor, EncodeStructFullRoundTrip) {
+  Msg m{ 42, "hero", 3.5, true, std::optional<int64_t>{7}, {10, 20, 30}, Inner{ -1, "z" } };
+  std::string bytes = qbuem::cbor::encode(m);
+  ASSERT_FALSE(bytes.empty());
+  ASSERT_EQ((uint8_t)bytes[0], 0xbf); // indefinite-length map
+
+  Rd r{ (const uint8_t *)bytes.data(), (const uint8_t *)bytes.data() + bytes.size() };
+  ASSERT_TRUE(r.open_indef_map());
+  EXPECT_EQ(r.rd_text(), "id");     EXPECT_EQ(r.rd_int(), 42);
+  EXPECT_EQ(r.rd_text(), "name");   EXPECT_EQ(r.rd_text(), "hero");
+  EXPECT_EQ(r.rd_text(), "score");  EXPECT_DOUBLE_EQ(r.rd_double(), 3.5);
+  EXPECT_EQ(r.rd_text(), "active"); EXPECT_TRUE(r.rd_bool());
+  EXPECT_EQ(r.rd_text(), "opt");    EXPECT_EQ(r.rd_int(), 7);
+  EXPECT_EQ(r.rd_text(), "nums");
+  EXPECT_EQ(r.open_array(), 3u);
+  EXPECT_EQ(r.rd_int(), 10); EXPECT_EQ(r.rd_int(), 20); EXPECT_EQ(r.rd_int(), 30);
+  EXPECT_EQ(r.rd_text(), "inner");
+  ASSERT_TRUE(r.open_indef_map());
+  EXPECT_EQ(r.rd_text(), "a"); EXPECT_EQ(r.rd_int(), -1); // negative int
+  EXPECT_EQ(r.rd_text(), "b"); EXPECT_EQ(r.rd_text(), "z");
+  ASSERT_TRUE(r.at_break()); r.skip_break();              // inner map break
+  ASSERT_TRUE(r.at_break()); r.skip_break();              // outer map break
+  EXPECT_EQ(r.p, r.e);                                    // consumed exactly
+}
+
+TEST(Cbor, EncodeOptionalEmptyIsNull) {
+  Msg m{ 1, "x", 1.0, false, std::nullopt, {}, Inner{ 0, "" } };
+  std::string b = qbuem::cbor::encode(m);
+  Rd r{ (const uint8_t *)b.data(), (const uint8_t *)b.data() + b.size() };
+  r.open_indef_map();
+  r.rd_text(); r.rd_int();    // id
+  r.rd_text(); r.rd_text();   // name
+  r.rd_text(); r.rd_double(); // score
+  r.rd_text(); r.rd_bool();   // active
+  EXPECT_EQ(r.rd_text(), "opt");
+  EXPECT_TRUE(r.is_null());   // nullopt → CBOR null
+  EXPECT_EQ(r.rd_text(), "nums");
+  EXPECT_EQ(r.open_array(), 0u); // empty vector → empty array
+}
+
+// ── decode: full encode → decode round-trip recovers every field ─────────────
+TEST(Cbor, RoundTripRecoversAllFields) {
+  Msg in{ 42, "hero", 3.5, true, std::optional<int64_t>{7}, {10, 20, 30}, Inner{ -1, "z" } };
+  std::string bytes = qbuem::cbor::encode(in);
+  Msg out = qbuem::cbor::decode<Msg>(bytes);
+  EXPECT_EQ(out.id, 42);
+  EXPECT_EQ(out.name, "hero");
+  EXPECT_DOUBLE_EQ(out.score, 3.5);
+  EXPECT_TRUE(out.active);
+  ASSERT_TRUE(out.opt.has_value());
+  EXPECT_EQ(*out.opt, 7);
+  EXPECT_EQ(out.nums, (std::vector<int64_t>{10, 20, 30}));
+  EXPECT_EQ(out.inner.a, -1);
+  EXPECT_EQ(out.inner.b, "z");
+}
+
+TEST(Cbor, RoundTripNulloptAndEmpty) {
+  Msg in{ 1, "x", 1.0, false, std::nullopt, {}, Inner{ 0, "" } };
+  Msg out = qbuem::cbor::decode<Msg>(qbuem::cbor::encode(in));
+  EXPECT_EQ(out.id, 1);
+  EXPECT_FALSE(out.active);
+  EXPECT_FALSE(out.opt.has_value()); // CBOR null → nullopt
+  EXPECT_TRUE(out.nums.empty());
+}
+
+// ── decode: interop with a foreign encoder (definite-length map, smallest ints,
+// out-of-order keys, an unknown extra key, single/half floats) ──────────────
+TEST(Cbor, DecodeForeignDefiniteMap) {
+  Wr w;
+  w.def_map(8);                          // definite-length map, 8 entries
+  w.key("name");  w.str("zed");          // keys out of struct order
+  w.key("id");    w.i(-5);
+  w.key("extra"); w.i(999);              // unknown key → must be skipped
+  w.key("active");w.boolean(true);
+  w.key("score"); w.i(4);                // integer where a double field is expected
+  w.key("opt");   w.null();              // null → nullopt
+  w.key("nums");  w.def_arr(2); w.u(7); w.u(8);
+  w.key("inner"); w.def_map(2); w.key("b"); w.str("q"); w.key("a"); w.i(3);
+
+  Msg m = qbuem::cbor::decode<Msg>(w.b);
+  EXPECT_EQ(m.id, -5);
+  EXPECT_EQ(m.name, "zed");
+  EXPECT_DOUBLE_EQ(m.score, 4.0);        // int decoded into double
+  EXPECT_TRUE(m.active);
+  EXPECT_FALSE(m.opt.has_value());
+  EXPECT_EQ(m.nums, (std::vector<int64_t>{7, 8}));
+  EXPECT_EQ(m.inner.a, 3);
+  EXPECT_EQ(m.inner.b, "q");
+}
+
+TEST(Cbor, DecodeHalfAndSingleFloat) {
+  // score via half-float 0x4200 = 3.0; then via single-precision.
+  { Wr w; w.def_map(1); w.key("score"); w.f16(0x4200);
+    Msg m = qbuem::cbor::decode<Msg>(w.b); EXPECT_DOUBLE_EQ(m.score, 3.0); }
+  { Wr w; w.def_map(1); w.key("score"); w.f32(2.5f);
+    Msg m = qbuem::cbor::decode<Msg>(w.b); EXPECT_DOUBLE_EQ(m.score, 2.5); }
+}
+
+// ── STL container coverage: map, fixed array, pair ───────────────────────────
+TEST(Cbor, RoundTripStlContainers) {
+  Bag in{ { {"a", 1}, {"b", 2} }, { 7, 8, 9 }, { "k", 42 } };
+  Bag out = qbuem::cbor::decode<Bag>(qbuem::cbor::encode(in));
+  EXPECT_EQ(out.dict.size(), 2u);
+  EXPECT_EQ(out.dict.at("a"), 1);
+  EXPECT_EQ(out.dict.at("b"), 2);
+  EXPECT_EQ(out.trip, (std::array<int64_t, 3>{7, 8, 9}));
+  EXPECT_EQ(out.kv.first, "k");
+  EXPECT_EQ(out.kv.second, 42);
+}
+
+// ── Unsigned 64-bit round-trip (raw arg path, no int64 narrowing) ────────────
+TEST(Cbor, RoundTripUnsigned64) {
+  U64 in{ 0xFFFFFFFFFFFFFFFAull };       // top bit set — would corrupt via int64
+  U64 out = qbuem::cbor::decode<U64>(qbuem::cbor::encode(in));
+  EXPECT_EQ(out.big, 0xFFFFFFFFFFFFFFFAull);
+}
+
+// ── Malformed input is rejected, never read out of bounds ────────────────────
+TEST(Cbor, TruncatedInputThrows) {
+  std::string bytes = qbuem::cbor::encode(Msg{ 1, "abc", 1.0, true, std::nullopt, {1, 2}, Inner{ 0, "" } });
+  for (size_t cut = 1; cut < bytes.size(); ++cut) {
+    std::string truncated = bytes.substr(0, cut);
+    // Either throws parse_error or decodes a partial object, but must not crash
+    // or read past the buffer (ASan/UBSan in CI proves the latter).
+    try { (void)qbuem::cbor::decode<Msg>(truncated); }
+    catch (const qbuem::parse_error &) { /* expected for most cut points */ }
+  }
+}
+
+TEST(Cbor, TypeMismatchThrows) {
+  Wr w; w.def_map(1); w.key("name"); w.u(123); // number where string expected
+  EXPECT_THROW((void)qbuem::cbor::decode<Msg>(w.b), qbuem::parse_error);
+}


### PR DESCRIPTION
## What

Adds a general-purpose binary codec to qbuem-json: the **same `QBUEM_JSON_FIELDS` field list** now also drives CBOR (RFC 8949) encode + decode. Register a struct once, serialize to **both** JSON and CBOR.

```cpp
std::string bytes = qbuem::cbor::encode(obj);        // → CBOR
T           obj   = qbuem::cbor::decode<T>(bytes);   // ← CBOR  (throws parse_error on bad input)
```

## Why CBOR (over a custom binary format)

- **Cross-language by design** — the bytes decode in any RFC 8949 reader (e.g. JS `cbor-x`) with **no shared schema**. A C++-only custom format would force a hand-maintained foreign decoder on every consumer.
- **Low maintenance** — reuses the existing field reflection + concept dispatch. Encode mirrors `append_json`; decode mirrors `from_json`. No new per-type code.

## Coverage

- **Encode** (`append_cbor`): null / bool / int (major 0/1) / double (0xfb) / text / optional / sequence / set / map / array / tuple / nested struct. Structs emit an indefinite-length text-keyed map.
- **Decode** (`from_cbor` + `CborReader`): type-driven reader. Accepts anything an RFC 8949 encoder emits — definite **or** indefinite arrays/maps, half/single/double floats, smallest-int forms, out-of-order + unknown keys (skipped). `uint64` round-trips via the raw argument (no int64 narrowing).

## Hardened for untrusted network input

- Every buffer advance is **bounds-checked** → truncated/malformed input throws `qbuem::parse_error`, never reads OOB.
- Recursion is **depth-bounded (1024)** against stack exhaustion.
- The generated `qbuem_json_read_cbor` is a **template** → instantiates lazily, so existing `QBUEM_JSON_FIELDS` structs that never use CBOR are unaffected.

## Verification

- `tests/test_cbor.cpp`: round-trip, nullopt/empty, foreign definite-map interop, half/single float, STL containers, uint64, truncation sweep, type mismatch.
- **568/568 tests pass** (was 558). ASan + UBSan clean.
- `fuzz/fuzz_cbor.cpp` (12th libFuzzer target): decode hostile bytes + round-trip. Driven **8M iterations locally under ASan/UBSan, clean** (Apple clang ships no libFuzzer runtime; CI runs the real target on Linux).

Version bumped 1.0.8 → **1.1.0** (new backward-compatible feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)