### PR TITLE
perf: optimize the CBOR decode hot path (v1.1.3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(qbuem_json VERSION 1.1.2 LANGUAGES CXX)
+project(qbuem_json VERSION 1.1.3 LANGUAGES CXX)
 
 # Library Target
 add_library(qbuem_json INTERFACE)

--- a/include/qbuem_json/qbuem_json.hpp
+++ b/include/qbuem_json/qbuem_json.hpp
@@ -1,7 +1,15 @@
 /**
- * @brief qbuem-json v1.1.2 - High-Performance C++20 JSON Parser
- * @version 1.1.2
+ * @brief qbuem-json v1.1.3 - High-Performance C++20 JSON Parser
+ * @version 1.1.3
  *
+ * v1.1.3: CBOR DECODE hot-path optimization (same wire format). read_head splits
+ *         into a tiny inline fast path (value < 24, the common case) + an
+ *         out-of-line multi-byte tail; short field-name keys (≤8 B) verify by
+ *         length alone (the hash already IS the bytes, so it's a complete
+ *         anti-spoof check) skipping a per-field memcmp; multi-byte heads and
+ *         IEEE-754 doubles are read/written via bswap+memcpy instead of byte
+ *         loops. ~7% faster decode on all-scalar messages, ~15% on nested/struct
+ *         payloads. 571/571 green, ASan/UBSan + fuzz clean.
  * v1.1.2: CBOR encode/decode hot-path optimization (same wire format). Encode now
  *         runs through the FastWriter (stack buffer, batched flush), precomputes
  *         each struct field key at compile time, and bulk-writes multi-byte heads
@@ -8729,12 +8737,12 @@ QBUEM_INLINE void cbor_head(W &out, uint8_t major, uint64_t val) {
     b[1] = static_cast<char>(val >> 8); b[2] = static_cast<char>(val); n = 3;
   } else if (val <= 0xffffffffull) {
     b[0] = static_cast<char>(mt | 26);
-    for (int i = 0; i < 4; ++i) b[1 + i] = static_cast<char>(val >> (24 - 8 * i));
-    n = 5;
+    const uint32_t v = __builtin_bswap32(static_cast<uint32_t>(val));
+    std::memcpy(b + 1, &v, 4); n = 5;
   } else {
     b[0] = static_cast<char>(mt | 27);
-    for (int i = 0; i < 8; ++i) b[1 + i] = static_cast<char>(val >> (56 - 8 * i));
-    n = 9;
+    const uint64_t v = __builtin_bswap64(val);
+    std::memcpy(b + 1, &v, 8); n = 9;
   }
   json_write(out, b, n);
 }
@@ -8781,9 +8789,10 @@ template <typename W, typename T> void append_cbor(W &out, const T &in) {
     const double d = static_cast<double>(in);
     uint64_t bits;
     std::memcpy(&bits, &d, 8);
+    bits = __builtin_bswap64(bits); // host (LE) → CBOR big-endian
     char b[9];
     b[0] = static_cast<char>(0xfb);
-    for (int i = 0; i < 8; ++i) b[1 + i] = static_cast<char>(bits >> (56 - 8 * i));
+    std::memcpy(b + 1, &bits, 8);
     json_write(out, b, 9);
   } else if constexpr (std::is_same_v<T, std::string> ||
                        std::is_same_v<T, std::string_view>) {
@@ -8890,23 +8899,40 @@ struct CborReader {
                            static_cast<size_t>(end - begin)));
   }
   // Guarantee at least n more bytes; otherwise the payload is truncated.
-  void need(size_t n) const {
-    if (static_cast<size_t>(end - p) < n) fail("CBOR: truncated input");
+  QBUEM_INLINE void need(size_t n) const {
+    if (__builtin_expect(static_cast<size_t>(end - p) < n, 0))
+      fail("CBOR: truncated input");
   }
 
   // Read an initial byte + its finite argument; sets mt to the major type.
   // Rejects additional-info 28..31 (reserved / indefinite — handled by the
   // header readers, never as a plain argument).
-  uint64_t read_head(uint8_t &mt) {
+  //
+  // Hot/cold split: the overwhelmingly common case is a value < 24 packed into
+  // the initial byte (every small int, every short key length, every small
+  // count). That path stays inline and ~5 instructions; the 1/2/4/8-byte
+  // argument assembly is moved out-of-line so it never bloats the caller and the
+  // inliner can fold this into the per-field decode loop.
+  QBUEM_INLINE uint64_t read_head(uint8_t &mt) {
     need(1);
     const uint8_t ib = *p++;
     mt = static_cast<uint8_t>(ib >> 5);
     const uint8_t ai = ib & 31;
-    if (ai < 24) return ai;
+    if (__builtin_expect(ai < 24, 1)) return ai;
+    return read_head_big(ai);
+  }
+  // Cold path: additional-info 24..27 (1/2/4/8 big-endian arg bytes).
+  uint64_t read_head_big(uint8_t ai) {
     if (ai == 24) { need(1); return *p++; }
     if (ai == 25) { need(2); uint64_t v = (uint64_t(p[0]) << 8) | p[1]; p += 2; return v; }
-    if (ai == 26) { need(4); uint64_t v = 0; for (int i = 0; i < 4; ++i) v = (v << 8) | *p++; return v; }
-    if (ai == 27) { need(8); uint64_t v = 0; for (int i = 0; i < 8; ++i) v = (v << 8) | *p++; return v; }
+    if (ai == 26) {
+      need(4); uint32_t v; std::memcpy(&v, p, 4); p += 4;
+      return __builtin_bswap32(v);
+    }
+    if (ai == 27) {
+      need(8); uint64_t v; std::memcpy(&v, p, 8); p += 8;
+      return __builtin_bswap64(v);
+    }
     fail("CBOR: reserved/indefinite additional-info");
   }
 
@@ -8925,17 +8951,17 @@ struct CborReader {
   }
   void read_null() { if (!try_read_null()) fail("CBOR: expected null"); }
 
-  double read_float() {
+  QBUEM_INLINE double read_float() {
     need(1);
     const uint8_t ib = *p;
-    if (ib == 0xfb) {
-      need(9); ++p; uint64_t b = 0;
-      for (int i = 0; i < 8; ++i) b = (b << 8) | *p++;
+    if (__builtin_expect(ib == 0xfb, 1)) {       // double — the common encoding
+      need(9); ++p; uint64_t b; ::std::memcpy(&b, p, 8); p += 8;
+      b = __builtin_bswap64(b);
       double d; ::std::memcpy(&d, &b, 8); return d;
     }
     if (ib == 0xfa) {
-      need(5); ++p; uint32_t b = 0;
-      for (int i = 0; i < 4; ++i) b = (b << 8) | *p++;
+      need(5); ++p; uint32_t b; ::std::memcpy(&b, p, 4); p += 4;
+      b = __builtin_bswap32(b);
       float f; ::std::memcpy(&f, &b, 4); return static_cast<double>(f);
     }
     if (ib == 0xf9) {
@@ -8950,9 +8976,9 @@ struct CborReader {
     fail("CBOR: expected float or integer");
   }
 
-  ::std::string_view read_text() {
+  QBUEM_INLINE ::std::string_view read_text() {
     uint8_t mt; uint64_t n = read_head(mt);
-    if (mt != 3) fail("CBOR: expected text string");
+    if (__builtin_expect(mt != 3, 0)) fail("CBOR: expected text string");
     need(static_cast<size_t>(n));
     const char *s = reinterpret_cast<const char *>(p);
     p += n;
@@ -8960,22 +8986,22 @@ struct CborReader {
   }
 
   // Open an array/map. Returns the entry count, or kCborIndef for 0x9f/0xbf.
-  size_t read_array_header() {
+  QBUEM_INLINE size_t read_array_header() {
     need(1);
-    if (*p == 0x9f) { ++p; return kCborIndef; }
+    if (__builtin_expect(*p == 0x9f, 0)) { ++p; return kCborIndef; }
     uint8_t mt; uint64_t n = read_head(mt);
-    if (mt != 4) fail("CBOR: expected array");
+    if (__builtin_expect(mt != 4, 0)) fail("CBOR: expected array");
     return static_cast<size_t>(n);
   }
-  size_t read_map_header() {
+  QBUEM_INLINE size_t read_map_header() {
     need(1);
-    if (*p == 0xbf) { ++p; return kCborIndef; }
+    if (__builtin_expect(*p == 0xbf, 0)) { ++p; return kCborIndef; }
     uint8_t mt; uint64_t n = read_head(mt);
-    if (mt != 5) fail("CBOR: expected map");
+    if (__builtin_expect(mt != 5, 0)) fail("CBOR: expected map");
     return static_cast<size_t>(n);
   }
   // For indefinite items: true while more entries remain (i.e. not at break).
-  bool peek_break() { need(1); return *p == 0xff; }
+  QBUEM_INLINE bool peek_break() { need(1); return *p == 0xff; }
   void consume_break() {
     need(1);
     if (*p != 0xff) fail("CBOR: expected break");
@@ -9111,6 +9137,21 @@ template <typename T> void from_cbor(CborReader &cr, T &out) {
   }
 }
 
+// Verify an incoming CBOR map key against a compile-time field name, AFTER its
+// hash already matched the field's switch case. The hash is collision-prone, so
+// a verify is mandatory (defends against an attacker routing a forged key into
+// the wrong field). But for names ≤ 8 bytes, fast_key_hash IS the raw
+// little-endian bytes, so "equal hash + equal length" already proves the bytes
+// are identical — a single length compare is a *complete* defense and skips the
+// memcmp on every field. Longer names (9+ bytes, where the hash folds/FNVs and
+// can genuinely collide) fall back to a full byte compare.
+template <std::size_t M>
+QBUEM_INLINE bool cbor_key_matches(std::string_view key, const char (&name)[M]) {
+  constexpr std::size_t L = M - 1; // exclude NUL
+  if constexpr (L <= 8) return key.size() == L;
+  else                  return key == std::string_view(name, L);
+}
+
 // ── Per-field helpers for QBUEM_JSON_FIELDS
 
 template <typename T>
@@ -9230,7 +9271,7 @@ inline void to_json_field(Value &obj, const char *key, const T &val) {
 // unmatched key has its value skipped wholesale.
 #define QBUEM_JSON_DETAIL_CBOR_READ(f)                                         \
   case ::qbuem::json::detail::fast_key_hash_ce(#f):                            \
-    if (_key == ::std::string_view(#f, sizeof(#f) - 1))                        \
+    if (::qbuem::json::detail::cbor_key_matches(_key, #f))                     \
       ::qbuem::json::detail::from_cbor(_cr, obj.f);                            \
     else                                                                       \
       ::qbuem::json::detail::cbor_skip(_cr);                                   \


### PR DESCRIPTION
## What

Decode-side speedup for the CBOR codec. After v1.1.2 made **encode** faster than the JSON serializer, **decode** was the remaining ~2× gap (it must dispatch on a key per field — work encode doesn't do). Same wire format, pure speed. All changes in the single header.

### Changes
1. **`read_head` hot/cold split** — the common case (value `< 24` packed into the initial byte: every small int, short key length, small count) is now ~5 inline instructions; the 1/2/4/8-byte argument tail moves out-of-line (`read_head_big`) so the inliner folds `read_head` into the per-field decode loop. Hot accessors (`need`/`read_text`/`read_array_header`/`read_map_header`/`peek_break`/`read_float`) marked `QBUEM_INLINE` with `__builtin_expect` on cold branches.
2. **Short-key verify by length** — a map key whose hash matched a field's switch case still needs a byte verify (the hash is collision-prone → anti-spoof). But for field names ≤ 8 bytes, `fast_key_hash` *is* the raw little-endian bytes, so "hash matched + same length" already proves byte-equality. `cbor_key_matches()` does one length compare and skips the per-field memcmp; names ≥ 9 bytes keep the full compare.
3. **bswap I/O** — multi-byte heads and IEEE-754 doubles read/write via `memcpy` + `__builtin_bswap{32,64}` instead of byte loops (consistent with the lib's existing LE assumption in `fast_key_hash`). Every read stays behind `need()`.

## Measured (`-O3 -march=native`, same benchmark binary, base vs new header, interleaved)

| Payload | decode BASE | decode NEW | Δ |
|---|---|---|---|
| AOI delta (16 entities × 7 ints, all-scalar hot path) | ~1110 ns | ~1029 ns | **−7.3%** |
| Nested snapshot (strings/optionals/vectors/nested) | ~1431 ns | ~1219 ns | **−14.8%** |

Encode flat. **Wire bytes byte-identical** (v1.1.2 FastWriter byte-identity test still green). For reference, CBOR decode remains ~4× faster than JSON decode.

## Verification
- **571/571** tests pass (Release + ASan/UBSan).
- `test_cbor` ASan/UBSan clean.
- CBOR fuzz harness driven **8M iterations under ASan/UBSan clean** — the new bswap+memcpy reads are all guarded by `need()`, and the length-only verify was exercised against forged / over-long keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)