### PR TITLE
perf: CBOR decode positional fast path (v1.1.4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(qbuem_json VERSION 1.1.3 LANGUAGES CXX)
+project(qbuem_json VERSION 1.1.4 LANGUAGES CXX)
 
 # Library Target
 add_library(qbuem_json INTERFACE)

--- a/include/qbuem_json/qbuem_json.hpp
+++ b/include/qbuem_json/qbuem_json.hpp
@@ -1,7 +1,14 @@
 /**
- * @brief qbuem-json v1.1.3 - High-Performance C++20 JSON Parser
- * @version 1.1.3
+ * @brief qbuem-json v1.1.4 - High-Performance C++20 JSON Parser
+ * @version 1.1.4
  *
+ * v1.1.4: CBOR DECODE positional fast path (same wire format). A struct map whose
+ *         keys arrive in declaration order (our own encoder, and most others,
+ *         preserve order) is decoded with one direct byte compare per field — no
+ *         hash, no switch indirect branch. The first out-of-order key flips to
+ *         the existing hash-dispatch loop, so reordered / foreign / partial maps
+ *         stay correct. ~1.4–1.8x faster struct decode (all-scalar messages land
+ *         near the key-less floor). 572/572 green, ASan/UBSan + 8M-iter fuzz clean.
  * v1.1.3: CBOR DECODE hot-path optimization (same wire format). read_head splits
  *         into a tiny inline fast path (value < 24, the common case) + an
  *         out-of-line multi-byte tail; short field-name keys (≤8 B) verify by
@@ -9000,6 +9007,25 @@ struct CborReader {
     if (__builtin_expect(mt != 5, 0)) fail("CBOR: expected map");
     return static_cast<size_t>(n);
   }
+  // Non-destructive: is the next item a 1-byte-head text string whose bytes
+  // equal `name` (a compile-time field name)? Powers the positional decode fast
+  // path — it confirms the expected next key WITHOUT the hash + switch dispatch.
+  // A long key (>= 24 B, 2-byte head) or any mismatch returns false, so the
+  // caller falls back to the general hash loop. The compare is a FULL byte
+  // compare, so it is itself a complete anti-spoof check, independent of the
+  // hash. Does not advance p (the entry stays available for the slow path).
+  template <std::size_t M>
+  QBUEM_INLINE bool peek_key_eq(const char (&name)[M]) const {
+    constexpr std::size_t L = M - 1; // field name length (excl. NUL)
+    if constexpr (L == 0 || L >= 24) return false;
+    if (static_cast<std::size_t>(end - p) < 1 + L) return false;
+    if (static_cast<uint8_t>(p[0]) != static_cast<uint8_t>(0x60 | L)) return false;
+    return __builtin_memcmp(p + 1, name, L) == 0;
+  }
+  // Advance past a confirmed 1-byte-head text key of length L (after a true
+  // peek_key_eq — bounds already validated there).
+  QBUEM_INLINE void skip_short_key(std::size_t L) { p += 1 + L; }
+
   // For indefinite items: true while more entries remain (i.e. not at break).
   QBUEM_INLINE bool peek_break() { need(1); return *p == 0xff; }
   void consume_break() {
@@ -9277,6 +9303,24 @@ inline void to_json_field(Value &obj, const char *key, const T &val) {
       ::qbuem::json::detail::cbor_skip(_cr);                                   \
     break;
 
+// QBUEM_JSON_DETAIL_CBOR_FAST — one step of the positional fast path. While the
+// map's keys arrive in struct-declaration order (the common case — our own
+// encoder, and most others, preserve field order), each field is confirmed with
+// a single non-destructive byte compare and decoded directly: no hash, no switch
+// indirect branch, no separate verify. The first key that does NOT match the
+// expected field flips _bfast off, leaving that (and every later) entry to the
+// general hash-dispatch loop below — so reordered / foreign / partial maps stay
+// correct, just without the fast path.
+#define QBUEM_JSON_DETAIL_CBOR_FAST(f)                                         \
+  if (_bfast && (_bindef ? !_cr.peek_break() : (_bi < _bn)) &&                 \
+      _cr.peek_key_eq(#f)) {                                                   \
+    _cr.skip_short_key(sizeof(#f) - 1);                                        \
+    ::qbuem::json::detail::from_cbor(_cr, obj.f);                              \
+    ++_bi;                                                                     \
+  } else {                                                                     \
+    _bfast = false;                                                           \
+  }
+
 #define QBUEM_JSON_FIELDS(Type, ...)                                           \
   /* Fast dispatch on pre-computed key hash — primary hot path */              \
   inline void nexus_pulse_h(uint64_t _h, ::std::string_view _key,             \
@@ -9332,11 +9376,16 @@ inline void to_json_field(Value &obj, const char *key, const T &val) {
      append_cbor template above. */                                            \
   template <typename _R>                                                       \
   inline void qbuem_json_read_cbor(_R &_cr, Type &obj) {                        \
-    const ::std::size_t _n = _cr.read_map_header();                            \
-    for (::std::size_t _i = 0;                                                  \
-         (_n == ::qbuem::json::detail::kCborIndef) ? !_cr.peek_break()         \
-                                                   : (_i < _n);                 \
-         ++_i) {                                                                \
+    const ::std::size_t _bn = _cr.read_map_header();                           \
+    const bool _bindef = (_bn == ::qbuem::json::detail::kCborIndef);           \
+    ::std::size_t _bi = 0;                                                      \
+    bool _bfast = true;                                                        \
+    /* Positional fast path: consume the in-order prefix with direct key       \
+       compares (no hash / switch); bails to the loop below on first mismatch. */\
+    QBUEM_FOR_EACH(QBUEM_JSON_DETAIL_CBOR_FAST, __VA_ARGS__)                    \
+    (void)_bfast;                                                              \
+    /* General path: remaining entries (reordered / unknown / foreign maps). */\
+    for (; _bindef ? !_cr.peek_break() : (_bi < _bn); ++_bi) {                  \
       const ::std::string_view _key = _cr.read_text();                         \
       switch (::qbuem::json::detail::fast_key_hash(_key)) {                     \
         QBUEM_FOR_EACH(QBUEM_JSON_DETAIL_CBOR_READ, __VA_ARGS__)                \
@@ -9345,7 +9394,7 @@ inline void to_json_field(Value &obj, const char *key, const T &val) {
         break;                                                                  \
       }                                                                         \
     }                                                                          \
-    if (_n == ::qbuem::json::detail::kCborIndef) _cr.consume_break();           \
+    if (_bindef) _cr.consume_break();                                          \
   }
 
 

--- a/tests/test_cbor.cpp
+++ b/tests/test_cbor.cpp
@@ -176,6 +176,50 @@ TEST(Cbor, DecodeForeignDefiniteMap) {
   EXPECT_EQ(m.inner.b, "q");
 }
 
+// ── Positional fast path (v1.1.4): in-order, fully-reversed, and fast-prefix-
+// then-reordered maps must ALL decode identically. The fast path consumes the
+// in-order prefix; the first out-of-order key flips it to the hash-dispatch
+// fallback. Build a foreign map per ordering and assert the same result. ───────
+static void put_field(Wr &w, const char *k, const Msg &m) {
+  std::string_view key(k);
+  w.key(k);
+  if (key == "id")          w.i(m.id);
+  else if (key == "name")   w.str(m.name);
+  else if (key == "score")  w.f64(m.score);
+  else if (key == "active") w.boolean(m.active);
+  else if (key == "opt")    { if (m.opt) w.i(*m.opt); else w.null(); }
+  else if (key == "nums")   { w.def_arr(m.nums.size()); for (auto n : m.nums) w.i(n); }
+  else /* inner */          { w.def_map(2); w.key("a"); w.i(m.inner.a); w.key("b"); w.str(m.inner.b); }
+}
+static Msg decode_in_order(const Msg &src, std::vector<const char *> order) {
+  Wr w; w.def_map(order.size());
+  for (auto *k : order) put_field(w, k, src);
+  return qbuem::cbor::decode<Msg>(w.b);
+}
+TEST(Cbor, PositionalFastPathOrderings) {
+  const Msg src{ 7, "kai", 2.25, true, std::optional<int64_t>{99}, {3, 4, 5}, Inner{ -8, "qq" } };
+  auto check = [&](const Msg &m) {
+    EXPECT_EQ(m.id, 7);
+    EXPECT_EQ(m.name, "kai");
+    EXPECT_DOUBLE_EQ(m.score, 2.25);
+    EXPECT_TRUE(m.active);
+    ASSERT_TRUE(m.opt.has_value());
+    EXPECT_EQ(*m.opt, 99);
+    EXPECT_EQ(m.nums, (std::vector<int64_t>{3, 4, 5}));
+    EXPECT_EQ(m.inner.a, -8);
+    EXPECT_EQ(m.inner.b, "qq");
+  };
+  // 1. Exact struct order — the all-fast path consumes every field.
+  check(decode_in_order(src, {"id", "name", "score", "active", "opt", "nums", "inner"}));
+  // 2. Fully reversed — fast path bails on the very first key (full fallback).
+  check(decode_in_order(src, {"inner", "nums", "opt", "active", "score", "name", "id"}));
+  // 3. Fast prefix then reorder — fast consumes id,name,score, then the next key
+  //    (opt, not active) flips to the hash fallback for the remaining four.
+  check(decode_in_order(src, {"id", "name", "score", "opt", "active", "nums", "inner"}));
+  // 4. Single swap in the middle.
+  check(decode_in_order(src, {"id", "name", "active", "score", "opt", "nums", "inner"}));
+}
+
 TEST(Cbor, DecodeHalfAndSingleFloat) {
   // score via half-float 0x4200 = 3.0; then via single-precision.
   { Wr w; w.def_map(1); w.key("score"); w.f16(0x4200);


### PR DESCRIPTION
## What

The big decode win. v1.1.3 left ~half of struct-decode time in the **per-field key dispatch** (read key → `fast_key_hash` → `switch` indirect branch → verify) — the inherent cost of a schema-less, key-tagged CBOR map. But keys almost always arrive in **struct-declaration order** (our encoder emits a definite map in field order; most encoders preserve order), so that dispatch is usually avoidable.

`qbuem_json_read_cbor` now runs a **positional fast path** first: for each field in order, a single non-destructive byte compare (`CborReader::peek_key_eq`) confirms the expected next key, then the value is decoded directly — no hash, no switch, no separate verify. The **first** key that doesn't match flips the fast path off; that entry + all remaining entries fall through to the **existing hash-dispatch loop**. So reordered / foreign / partial / unknown-key maps decode exactly as before — only the common in-order case is accelerated.

The peek is a **full byte compare**, a complete anti-spoof check on its own (independent of the hash).

## Measured (`-O3 -march=native`, same benchmark binary, base v1.1.3 vs new, interleaved)

| Payload | decode v1.1.3 | decode v1.1.4 | Δ |
|---|---|---|---|
| AOI delta (16 entities × 7 ints, all-scalar) | ~1001 ns | **~570 ns** | **−43% (1.76×)** |
| Nested snapshot (strings/optionals/vectors/nested) | ~1184 ns | **~827 ns** | **−30% (1.43×)** |

The all-scalar AOI decode (570 ns) now lands near the **473 ns key-less-array floor** — i.e. close to the theoretical limit while keeping the cross-language map format. Encode unchanged. **Wire bytes byte-identical** (v1.1.2 byte-identity test green).

## Correctness & safety
- New `PositionalFastPathOrderings` test: in-order (all-fast), fully reversed (full fallback), fast-prefix-then-reorder, and a mid swap all decode **identically**.
- **572/572** tests pass (Release + ASan/UBSan); `test_cbor` ASan/UBSan clean.
- CBOR fuzz harness driven **8M iterations under ASan/UBSan clean** — `peek_key_eq` reads are bounds-guarded; the fast/fallback split was hammered with hostile bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)