### PR TITLE
docs: CBOR section (guide + theory + benchmarks + SEO)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -97,7 +97,7 @@ export default withMermaid(
             ['meta', { name: 'theme-color', content: '#1a2744' }],
 
             // SEO - Core
-            ['meta', { name: 'keywords', content: 'C++ JSON, C++20 JSON library, fastest JSON parser, SIMD JSON, AVX-512 JSON, zero-allocation JSON, high-performance JSON, HFT JSON, JSON serializer, single header JSON, qbuem-json, nlohmann alternative, simdjson alternative, RapidJSON alternative' }],
+            ['meta', { name: 'keywords', content: 'C++ JSON, C++20 JSON library, fastest JSON parser, SIMD JSON, AVX-512 JSON, zero-allocation JSON, high-performance JSON, HFT JSON, JSON serializer, single header JSON, qbuem-json, CBOR C++, RFC 8949, binary serialization C++, C++ CBOR library, cbor-x interop, nlohmann alternative, simdjson alternative, RapidJSON alternative' }],
             ['meta', { name: 'author', content: 'qbuem-json Authors' }],
             ['meta', { name: 'robots', content: 'index, follow, max-image-preview:large' }],
 
@@ -179,22 +179,23 @@ export default withMermaid(
                         applicationCategory: 'DeveloperApplication',
                         applicationSubCategory: 'C++ Library',
                         operatingSystem: 'Linux, macOS',
-                        version: '1.0.8',
-                        softwareVersion: '1.0.8',
-                        releaseNotes: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.0.8',
-                        downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.0.8',
+                        version: '1.1.4',
+                        softwareVersion: '1.1.4',
+                        releaseNotes: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.1.4',
+                        downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.1.4',
                         installUrl: 'https://qbuem.com/qbuem-json/guide/getting-started',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
-                        keywords: 'C++ JSON library, C++20 JSON, fastest JSON parser, SIMD JSON, AVX-512 JSON, zero-allocation JSON, high-performance JSON, HFT JSON, JSON serializer, single header JSON, header-only JSON, nlohmann alternative, simdjson alternative, RapidJSON alternative',
+                        keywords: 'C++ JSON library, C++20 JSON, fastest JSON parser, SIMD JSON, AVX-512 JSON, zero-allocation JSON, high-performance JSON, HFT JSON, JSON serializer, single header JSON, header-only JSON, CBOR C++, RFC 8949 CBOR, binary serialization C++, nlohmann alternative, simdjson alternative, RapidJSON alternative',
                         featureList: [
                             'AVX-512 and ARM NEON SIMD acceleration',
                             'Zero-allocation flat tape DOM',
                             'Nexus Fusion: direct JSON-to-struct mapping (zero tape)',
+                            'CBOR (RFC 8949) binary codec — same field list, cross-language (e.g. JS cbor-x)',
                             'Single header file, zero external dependencies',
                             'C++20 concepts-based API',
-                            'RFC 8259, RFC 6901, RFC 6902 compliant',
+                            'RFC 8259, RFC 6901, RFC 6902, RFC 8949 compliant',
                             'IEEE 754 round-trip float correctness',
-                            '558 passing tests, 11 libFuzzer targets',
+                            '572 passing tests, 12 libFuzzer targets',
                             'STL container support (vector, map, optional, tuple, variant)',
                             'Up to 2.9 GB/s parsing, 7.2 GB/s serialization',
                             'Apache 2.0 license — free for commercial use',
@@ -230,7 +231,7 @@ export default withMermaid(
                         },
                         runtimePlatform: 'C++20',
                         targetProduct: { '@id': 'https://qbuem.com/qbuem-json/#application' },
-                        version: '1.0.8',
+                        version: '1.1.4',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
                         keywords: 'C++, JSON, SIMD, AVX-512, High-Performance, HFT, parser, serializer, zero-allocation',
                         author: { '@id': 'https://qbuem.com/#organization' }
@@ -343,6 +344,14 @@ export default withMermaid(
                             },
                             {
                                 '@type': 'Question',
+                                name: 'Can qbuem-json serialize to binary (CBOR)?',
+                                acceptedAnswer: {
+                                    '@type': 'Answer',
+                                    text: 'Yes. The same QBUEM_JSON_FIELDS registration also drives a CBOR (RFC 8949) binary codec: qbuem::cbor::encode<T>() and qbuem::cbor::decode<T>(). CBOR is self-describing, so the bytes decode in any language (for example the JavaScript cbor-x library) with no shared schema. Payloads are about 40% smaller than JSON and decode several times faster; the decoder is fully bounds-checked and fuzzed for untrusted network input.'
+                                }
+                            },
+                            {
+                                '@type': 'Question',
                                 name: 'Does qbuem-json support Windows?',
                                 acceptedAnswer: {
                                     '@type': 'Answer',
@@ -367,6 +376,7 @@ export default withMermaid(
             nav: [
                 { text: 'Guide', link: '/guide/introduction' },
                 { text: 'Architecture', link: '/theory/architecture' },
+                { text: 'CBOR', link: '/guide/cbor' },
                 { text: 'Benchmarks', link: '/guide/benchmarks' },
                 { text: 'Correctness', link: '/guide/correctness' },
                 {
@@ -377,9 +387,9 @@ export default withMermaid(
                     ]
                 },
                 {
-                    text: 'v1.0.8',
+                    text: 'v1.1.4',
                     items: [
-                        { text: 'Release Notes', link: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.0.8' },
+                        { text: 'Release Notes', link: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.1.4' },
                         { text: 'All Releases', link: 'https://github.com/qbuem/qbuem-json/releases' }
                     ]
                 }
@@ -402,6 +412,7 @@ export default withMermaid(
                         items: [
                             { text: 'Parsing & Access', link: '/guide/parsing' },
                             { text: 'Serialization', link: '/guide/serialization' },
+                            { text: 'CBOR (Binary)', link: '/guide/cbor' },
                             { text: 'Object Mapping (Macros)', link: '/guide/mapping' },
                             { text: 'Error Handling', link: '/guide/errors' }
                         ]
@@ -425,7 +436,8 @@ export default withMermaid(
                             { text: 'Numeric Serialization (Schubfach + yy-itoa)', link: '/theory/numeric-serialization' },
                             { text: 'The Russ Cox Algorithm', link: '/theory/russ-cox' },
                             { text: 'Zero-Allocation Principle', link: '/theory/zero-allocation' },
-                            { text: 'Nexus Fusion (Zero-Tape)', link: '/theory/nexus-fusion' }
+                            { text: 'Nexus Fusion (Zero-Tape)', link: '/theory/nexus-fusion' },
+                            { text: 'CBOR Binary Codec', link: '/theory/cbor' }
                         ]
                     }
                 ]

--- a/docs/guide/benchmarks.md
+++ b/docs/guide/benchmarks.md
@@ -26,6 +26,50 @@ Runs in parallel on three native GitHub-hosted runners (x86\_64 / Apple Silicon 
 
 ---
 
+## 📦 CBOR Binary Codec {#cbor-binary-codec}
+
+The [CBOR codec](./cbor) reuses the same `QBUEM_JSON_FIELDS` registration as the JSON
+engine. These numbers are a focused micro-benchmark (Apple Silicon M-series,
+single core, `-O3 -march=native`, reused output buffer — the hot-loop pattern),
+separate from the live CI dashboard above. They measure two representative
+game-server payloads.
+
+**CBOR vs JSON** — same struct, same data:
+
+| Payload | format | encode | decode | wire size |
+|:---|:---|---:|---:|---:|
+| AOI delta (16 entities × 7 ints) | **CBOR** | **515 ns** | **570 ns** | **590 B** |
+| AOI delta (16 entities × 7 ints) | JSON | 550 ns | 4309 ns | 1018 B |
+| Snapshot (8 players, nested/str/opt/vec) | **CBOR** | **409 ns** | **827 ns** | **880 B** |
+| Snapshot (8 players, nested/str/opt/vec) | JSON | 728 ns | 4557 ns | 1172 B |
+
+On the all-scalar hot path, CBOR **decode is ~7.5× faster than JSON** and the wire
+is **~42 % smaller**.
+
+**vs other CBOR codecs** — same payload (AOI delta), same map-keyed wire format:
+
+| Codec | encode | decode | notes |
+|:---|---:|---:|:---|
+| **qbuem-json** (reflection) | **515 ns** | **570 ns** | register fields once; bounds-checked |
+| hand-written (no reflection) | ~tuned-equal | 341 ns | the TinyCBOR/QCBOR-class ceiling; unsafe, every field by hand |
+| nlohmann/json (DOM) | 10175 ns | 15880 ns | the popular C++ choice |
+
+Against the most common C++ CBOR path (nlohmann's DOM-based `to_cbor`/`from_cbor`),
+qbuem-json is **~20× faster to encode and ~28× faster to decode**. Against a
+hand-written, reflection-free codec — the absolute ceiling, which gives up both
+safety and the convenience of struct registration — qbuem-json decode runs at
+~60 % of that speed while remaining bounds-checked and schema-driven. See
+[CBOR theory](../theory/cbor#decode-the-positional-fast-path) for how the
+positional fast path closes most of that gap.
+
+> The CBOR micro-benchmark source is `cbor` payloads built from `QBUEM_JSON_FIELDS`
+> structs; wire bytes are byte-identical across versions (a FastWriter
+> byte-identity regression test guards this). Numbers are single-machine and
+> carry the usual ±2 % build-to-build noise; the comparison binaries were run
+> interleaved to cancel it.
+
+---
+
 ## 🔗 Language Bindings Performance
 
 `qbuem-json` provides high-performance bindings for **Python**, **Go**, and **Rust**. The automated benchmark dashboard above includes a dedicated section for these bindings, comparing them against the native JSON libraries in each language.

--- a/docs/guide/cbor.md
+++ b/docs/guide/cbor.md
@@ -1,0 +1,139 @@
+# CBOR (Binary Serialization)
+
+**One field list, two wire formats.** The same `QBUEM_JSON_FIELDS` registration that drives JSON also drives a [CBOR (RFC 8949)](https://www.rfc-editor.org/rfc/rfc8949.html) binary codec — compact, self-describing bytes that decode in **any language** (e.g. JavaScript [`cbor-x`](https://github.com/kriszyp/cbor-x)) with no shared schema. Register a struct once; serialize it to both text and binary.
+
+```cpp
+#include <qbuem_json/qbuem_json.hpp>
+
+struct Child {
+    int64_t     id;
+    std::string name;
+    std::string birth_date;
+};
+QBUEM_JSON_FIELDS(Child, id, name, birth_date)   // outside the struct, namespace scope
+
+Child c{ 42, "Mina", "2018-04-01" };
+
+std::string bytes = qbuem::cbor::encode(c);       // → compact CBOR bytes
+Child       back  = qbuem::cbor::decode<Child>(bytes);   // ← back to the struct
+```
+
+That's the whole story: `qbuem::cbor::encode` / `qbuem::cbor::decode`, same struct, same field list as `qbuem::write` / `qbuem::read`.
+
+---
+
+## Why CBOR
+
+CBOR is a standardized, self-describing binary format — think "binary JSON" with an IETF spec. qbuem-json chose it over a hand-rolled custom binary format for three reasons:
+
+- **Cross-language by design.** The bytes carry their own type tags, so any RFC 8949 decoder reads them without a shared schema file. A C++ server can emit a frame that a TypeScript browser client decodes with `cbor-x` — no IDL, no codegen, no version drift between two hand-written codecs.
+- **Smaller and faster than JSON.** No quotes, no field-name repetition bloat beyond the keys themselves, integers and floats stored in their native binary width. Typical payloads are **~40% smaller** and decode **several times faster** than the equivalent JSON (see [Benchmarks](./benchmarks#cbor-binary-codec)).
+- **Zero new maintenance surface.** It reuses the existing field reflection and the same concept-based type dispatch as the JSON path. Registering a field once gets you JSON *and* CBOR; there is no second list to keep in sync.
+
+> **Rule of thumb.** Use **JSON** for config files, logs, debugging, and human-facing or REST surfaces. Use **CBOR** for hot-path machine-to-machine traffic — real-time WebSocket frames, game state deltas, bandwidth-constrained mobile links, and on-device binary persistence.
+
+---
+
+## API
+
+All CBOR entry points live in `namespace qbuem::cbor`. Bytes are carried in a `std::string` used as a byte container.
+
+```cpp
+// ── Encode ──────────────────────────────────────────────────────────────────
+std::string  qbuem::cbor::encode(const T& obj);            // → new byte string
+void         qbuem::cbor::encode_to(std::string& buf, const T& obj);  // append (reuses capacity)
+
+// ── Decode ──────────────────────────────────────────────────────────────────
+T            qbuem::cbor::decode<T>(std::string_view bytes);          // throws on bad input
+T            qbuem::cbor::decode<T>(const uint8_t* data, size_t n);   // (ptr, len) overload
+void         qbuem::cbor::decode_into<T>(std::string_view bytes, T& obj);  // fill existing object
+```
+
+- `decode<T>` throws [`qbuem::parse_error`](./errors) (with `.offset()`) on truncated, malformed, or type-mismatched input — it **never reads out of bounds**, so it is safe on untrusted network bytes.
+- Trailing bytes after the top-level item are ignored, which is convenient for length-framed messages (decode the item, advance by the frame length).
+- `encode_to` and `decode_into` reuse an existing buffer / object so a hot loop pays no per-message heap allocation.
+
+### Hot-loop pattern
+
+```cpp
+std::string scratch;                 // reused across frames — keeps its capacity
+for (const auto& delta : outgoing) {
+    scratch.clear();
+    qbuem::cbor::encode_to(scratch, delta);
+    socket.send_binary(scratch);     // one encode, zero re-allocation
+}
+```
+
+---
+
+## Supported types
+
+CBOR decode/encode covers the **same type set as the JSON engine** — register with `QBUEM_JSON_FIELDS` and these all work, nested arbitrarily:
+
+| C++ type | CBOR representation |
+|:---|:---|
+| `bool` | simple `true` / `false` |
+| `int*` / `uint*` (incl. `uint64_t`) | major 0 (unsigned) / major 1 (negative), smallest width |
+| `float` / `double` | IEEE-754 (decode also accepts half / single / integer) |
+| `std::string` | text string (major 3) |
+| `std::optional<T>` | the value, or `null` when empty |
+| `std::vector` / `std::list` / `std::deque` / sets | array (major 4) |
+| `std::map` / `std::unordered_map` | map (major 5) |
+| `std::array<T,N>` / `std::tuple` / `std::pair` | array (major 4) |
+| `QBUEM_JSON_FIELDS` struct | map (major 5) keyed by field name |
+
+`uint64_t` values with the top bit set round-trip exactly (the decoder reads the raw CBOR argument, with no `int64` narrowing).
+
+---
+
+## Cross-language interop
+
+A struct encoded by qbuem-json decodes directly in JavaScript/TypeScript with `cbor-x` — no schema:
+
+```cpp
+// C++ server
+struct Tick { int64_t t; double px; int64_t qty; };
+QBUEM_JSON_FIELDS(Tick, t, px, qty)
+
+std::string frame = qbuem::cbor::encode(Tick{ 1718, 101.25, 500 });
+ws.send_binary(frame);
+```
+
+```ts
+// TypeScript browser client
+import { decode } from 'cbor-x'
+
+ws.onmessage = (ev) => {
+  const tick = decode(new Uint8Array(ev.data))   // { t: 1718, px: 101.25, qty: 500 }
+}
+```
+
+Because qbuem-json emits a CBOR **map keyed by field name**, the decoded object on the other side is a plain keyed object — field order, missing optional fields, and forward-compatible extra fields all behave the way any RFC 8949 reader expects.
+
+---
+
+## Safety on untrusted input
+
+The decoder is built for bytes coming off a socket:
+
+- **Every buffer advance is bounds-checked** — a truncated or hostile payload raises `qbuem::parse_error`, never an out-of-bounds read.
+- **Recursion is depth-bounded** (1024) so a maliciously deep nesting can't exhaust the native stack.
+- It is exercised by a dedicated **libFuzzer target** (`fuzz_cbor`) under ASan/UBSan in CI, in addition to the unit suite.
+
+```cpp
+auto safe_decode(std::string_view frame) -> std::optional<Msg> {
+    try { return qbuem::cbor::decode<Msg>(frame); }
+    catch (const qbuem::parse_error& e) {
+        log_warn("bad CBOR frame at offset {}", e.offset());
+        return std::nullopt;
+    }
+}
+```
+
+---
+
+## See also
+
+- [CBOR Binary Codec (theory)](../theory/cbor) — the RFC 8949 data model, the definite-length map choice, and the positional decode fast path.
+- [Benchmarks → CBOR](./benchmarks#cbor-binary-codec) — measured encode/decode latency vs JSON and other CBOR libraries.
+- [Object Mapping (Macros)](./mapping) — the `QBUEM_JSON_FIELDS` registration shared by both engines.

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -317,6 +317,37 @@ root.dump(buf);  // dump also accepts a buffer ref
 
 ---
 
+## CBOR Binary Serialization (RFC 8949)
+
+The same `QBUEM_JSON_FIELDS` registration also drives a CBOR binary codec. CBOR is
+self-describing, so the bytes decode in any language (e.g. JavaScript `cbor-x`)
+with no shared schema — about 40% smaller than JSON and several times faster to
+decode. The decoder is fully bounds-checked and fuzzed for untrusted network input.
+
+```cpp
+struct Child { int64_t id; std::string name; std::string birth_date; };
+QBUEM_JSON_FIELDS(Child, id, name, birth_date)   // same list as JSON
+
+Child c{42, "Mina", "2018-04-01"};
+
+// Encode → compact CBOR bytes (std::string used as a byte buffer)
+std::string bytes = qbuem::cbor::encode(c);
+qbuem::cbor::encode_to(buf, c);                  // append into a reused buffer
+
+// Decode → struct (throws qbuem::parse_error on bad/truncated/mismatched input)
+Child back = qbuem::cbor::decode<Child>(bytes);              // string_view
+Child b2   = qbuem::cbor::decode<Child>(data_ptr, n);        // (ptr, len) overload
+qbuem::cbor::decode_into(bytes, existing);                   // fill existing object
+```
+
+- API lives in `namespace qbuem::cbor`: `encode`, `encode_to`, `decode<T>`, `decode_into<T>`.
+- Supports the same type set as the JSON engine: scalars, `std::string`, `std::optional`, `vector`/`list`/`deque`/sets, `map`, `std::array`/`tuple`/`pair`, and nested `QBUEM_JSON_FIELDS` structs. `uint64_t` round-trips exactly (no int64 narrowing).
+- Structs serialize to a definite-length CBOR map keyed by field name; trailing bytes after the top-level item are ignored (length-framed-message friendly).
+- Decode uses a positional fast path: when keys arrive in declaration order (the common case), each field is confirmed with one direct byte compare and decoded with no hash/switch; out-of-order/foreign maps fall back to hash dispatch. All advances are bounds-checked; recursion is capped at 1024.
+- Use JSON for config/logs/REST; use CBOR for hot-path machine-to-machine traffic (WebSocket frames, game deltas, bandwidth-constrained links, on-device binary persistence).
+
+---
+
 ## Mutations (Non-Destructive Overlay)
 
 The original tape is immutable. Mutations are stored in a fast overlay map.
@@ -447,16 +478,18 @@ Nexus Fusion: 50–230 ns for direct struct mapping (zero tape).
 
 Competitors (same benchmark): simdjson ~2.5 GB/s parse, yyjson ~2.3 GB/s, RapidJSON ~0.8 GB/s, nlohmann ~0.3 GB/s.
 
+CBOR codec (Apple Silicon, 16-entity × 7-int message, reused buffer): encode ~515 ns, decode ~570 ns, wire 590 B — vs the same data as JSON (encode ~550 ns, decode ~4300 ns, 1018 B). Against nlohmann's DOM-based CBOR (`to_cbor`/`from_cbor`), qbuem-json is ~20× faster to encode and ~28× faster to decode.
+
 ---
 
 ## Correctness & Safety
 
-- RFC 8259 (JSON), RFC 6901 (JSON Pointer), RFC 6902 (JSON Patch) compliant
+- RFC 8259 (JSON), RFC 6901 (JSON Pointer), RFC 6902 (JSON Patch), RFC 8949 (CBOR) compliant
 - IEEE 754 round-trip: `parse(serialize(x)) == x` for all finite doubles
 - Three-stage float parsing: Eisel-Lemire (~98.8%) → Russ Cox Unrounded Scaling (~1.2%) → strtod (subnormals <0.01%)
 - Float serialization: Schubfach (Giulietti 2020) — shortest decimal, no trailing zeros
-- 521 passing tests across 20 files (5,556 lines of test code)
-- 11 libFuzzer targets
+- 572 passing tests; CBOR decoder is bounds-checked and safe on untrusted input
+- 12 libFuzzer targets (including a dedicated CBOR fuzzer)
 - ASan, UBSan, TSan on every commit
 
 ---
@@ -494,6 +527,8 @@ Build flags for maximum performance:
 - Parsing Guide: https://qbuem.com/qbuem-json/guide/parsing
 - Type Mapping: https://qbuem.com/qbuem-json/guide/mapping
 - Serialization: https://qbuem.com/qbuem-json/guide/serialization
+- CBOR (Binary): https://qbuem.com/qbuem-json/guide/cbor
+- CBOR Theory: https://qbuem.com/qbuem-json/theory/cbor
 - Error Handling: https://qbuem.com/qbuem-json/guide/errors
 - Benchmarks: https://qbuem.com/qbuem-json/guide/benchmarks
 - Correctness: https://qbuem.com/qbuem-json/guide/correctness

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -6,6 +6,8 @@ qbuem-json ships two complementary engines in one header (`qbuem_json.hpp`):
 - **DOM engine** — flat tape architecture for flexible parsing; single arena allocation; up to 2.9 GB/s parsing, 7.2 GB/s serialization
 - **Nexus Fusion engine** — zero-tape, compile-time FNV-1a dispatch for direct JSON-to-struct mapping with micro-latency
 
+It also includes a **CBOR (RFC 8949) binary codec** driven by the same `QBUEM_JSON_FIELDS` registration: `qbuem::cbor::encode<T>()` / `decode<T>()`. CBOR is self-describing, so the bytes decode in any language (e.g. JavaScript `cbor-x`) with no shared schema — ~40% smaller than JSON and several times faster to decode, with a fully bounds-checked, fuzzed reader for untrusted input.
+
 Minimum requirements: C++20, GCC 13+ or Clang 18+ or Apple Clang. Supported platforms: Linux x86_64, Linux aarch64, macOS Apple Silicon. Windows is not supported.
 
 ## Docs
@@ -14,12 +16,13 @@ Minimum requirements: C++20, GCC 13+ or Clang 18+ or Apple Clang. Supported plat
 - [Getting Started](https://qbuem.com/qbuem-json/guide/getting-started): Installation (single header, CMake FetchContent, clone & build) and first usage examples
 - [Parsing & Access](https://qbuem.com/qbuem-json/guide/parsing): DOM parsing, value access, JSON Pointer, iteration, error handling
 - [Serialization](https://qbuem.com/qbuem-json/guide/serialization): Struct-to-JSON, STL container support, custom serialization hooks
+- [CBOR (Binary Serialization)](https://qbuem.com/qbuem-json/guide/cbor): RFC 8949 binary codec — qbuem::cbor::encode/decode from the same QBUEM_JSON_FIELDS list; cross-language (JS cbor-x), ~40% smaller than JSON, bounds-checked for untrusted input
 - [Object Mapping (Macros)](https://qbuem.com/qbuem-json/guide/mapping): QBUEM_JSON_FIELDS macro, nested structs, optional fields, STL type mappings
 - [Error Handling](https://qbuem.com/qbuem-json/guide/errors): ParseError, typed exceptions, safe vs. unsafe access patterns
 - [Custom Allocators](https://qbuem.com/qbuem-json/guide/allocators): Arena allocators, stack allocators, custom memory strategies
 - [Language Bindings](https://qbuem.com/qbuem-json/guide/bindings): C FFI, Python, Rust, Go bindings
 - [Low-Latency Patterns](https://qbuem.com/qbuem-json/guide/low-latency-patterns): HFT tick data patterns, pre-allocated documents, reuse strategies
-- [Correctness & Safety](https://qbuem.com/qbuem-json/guide/correctness): RFC 8259/6901/6902 compliance, IEEE 754 round-trip, 521 tests, sanitizers, fuzzing
+- [Correctness & Safety](https://qbuem.com/qbuem-json/guide/correctness): RFC 8259/6901/6902/8949 compliance, IEEE 754 round-trip, 572 tests, sanitizers, fuzzing
 - [Benchmarks](https://qbuem.com/qbuem-json/guide/benchmarks): Live CI benchmark results vs. simdjson, yyjson, RapidJSON, nlohmann
 - [Vision & Roadmap](https://qbuem.com/qbuem-json/guide/vision): Project goals and planned features
 
@@ -28,6 +31,7 @@ Minimum requirements: C++20, GCC 13+ or Clang 18+ or Apple Clang. Supported plat
 - [Tape Architecture](https://qbuem.com/qbuem-json/theory/architecture): How the flat-tape DOM eliminates tree-node allocation overhead
 - [SIMD Acceleration](https://qbuem.com/qbuem-json/theory/simd): AVX-512 (x86_64) and ARM NEON structural character scanning
 - [Nexus Fusion (Zero-Tape)](https://qbuem.com/qbuem-json/theory/nexus-fusion): Compile-time key dispatch, zero intermediate allocations
+- [CBOR Binary Codec](https://qbuem.com/qbuem-json/theory/cbor): RFC 8949 data model, definite-length keyed maps, compile-time key blobs, the positional decode fast path
 - [Numeric Serialization](https://qbuem.com/qbuem-json/theory/numeric-serialization): Schubfach algorithm (Giulietti 2020) + yy-itoa for integers
 - [The Russ Cox Algorithm](https://qbuem.com/qbuem-json/theory/russ-cox): Unrounded decimal-to-float scaling used in stage 2 of float parsing
 - [Zero-Allocation Principle](https://qbuem.com/qbuem-json/theory/zero-allocation): Memory layout, arena reuse, string_view zero-copy access

--- a/docs/theory/cbor.md
+++ b/docs/theory/cbor.md
@@ -1,0 +1,105 @@
+# CBOR Binary Codec
+
+qbuem-json serializes the same `QBUEM_JSON_FIELDS` struct to **two** wire formats: human-readable JSON and binary [CBOR (RFC 8949)](https://www.rfc-editor.org/rfc/rfc8949.html). This page explains the CBOR data model, the wire-format choices, and how the codec is tuned to land near the theoretical floor while staying schema-less and bounds-checked.
+
+For the practical API and a usage guide, see [CBOR (Binary Serialization)](../guide/cbor).
+
+---
+
+## The CBOR data model
+
+CBOR is, in effect, a standardized binary JSON. Every data item begins with one **initial byte** whose high 3 bits are the *major type* and whose low 5 bits are the *additional information* (a small value, or a code for how many argument bytes follow).
+
+| Major | Meaning | qbuem-json use |
+|:---:|:---|:---|
+| 0 | unsigned integer | `uint*`, non-negative `int*` |
+| 1 | negative integer (encoded as `−1 − n`) | negative `int*` |
+| 2 | byte string | — |
+| 3 | text string | `std::string`, field-name keys |
+| 4 | array | `vector` / `set` / `array` / `tuple` |
+| 5 | map | `QBUEM_JSON_FIELDS` structs, `std::map` |
+| 7 | simple / float | `bool`, `null`, `double` (`0xfb`) |
+
+The argument is encoded in the **smallest** width that fits: values `< 24` ride in the initial byte itself; otherwise 1, 2, 4, or 8 big-endian bytes follow (additional info `24`–`27`). This "small value in the head byte" case is overwhelmingly the common one — every small integer, every short field-name length, every modest array/map count — and the codec's hot paths are built around it.
+
+Because each item is **self-describing** (the type travels with the value), a CBOR byte stream can be decoded with no external schema. That is the property that lets a C++ server and a JavaScript client share bytes without sharing a generated codec.
+
+---
+
+## Wire-format choices
+
+### Structs are definite-length maps keyed by field name
+
+A `QBUEM_JSON_FIELDS` struct serializes to a CBOR **map** (major 5) whose keys are the field-name text strings. The field count is known at compile time, so the codec emits a **definite-length** header (`0xA0 | N` for `N < 24`) rather than an indefinite map (`0xBF … 0xFF`):
+
+$$
+\texttt{0xA7}\;[\;\texttt{"id"}\,\to\,42\;]\;[\;\texttt{"x"}\,\to\,-200\;]\;\dots
+$$
+
+The definite header is strictly better: it drops the trailing `break` byte and lets the decoder run a counted loop instead of a per-entry break check. It remains wire-compatible — the decoder accepts both definite and indefinite maps, as does any RFC 8949 reader.
+
+Keying by field name (rather than packing values positionally) is a deliberate trade. A positional array would be smaller and faster, but it would require both endpoints to agree on a schema — exactly the coupling CBOR is meant to avoid. The map keeps the format **schema-less and self-describing**; the optimizations below claw back most of the cost that choice implies.
+
+### Compile-time key blobs
+
+On encode, each field name is turned into its CBOR-encoded form (text header + bytes) **at compile time** via `make_cbor_key<>()`, living in `.rodata`. Emitting a field key is then a single bulk `memcpy` of a ready-made blob — the binary analogue of the JSON FastWriter's precomputed `"key":` literal — instead of re-deriving the header and length per call.
+
+---
+
+## Where the time goes
+
+The honest way to ask "is this fast enough?" is to decompose the cost. Encoding/decoding **112 `int64` fields** (16 entities × 7 fields), `-O3 -march=native`, Apple Silicon:
+
+| | encode | decode |
+|:---|---:|---:|
+| **STRUCT** (map, keyed — the real format) | 514 ns | 570 ns |
+| **ARRAY** (same ints, *no keys* — the floor) | 424 ns | 473 ns |
+| **= key-dispatch + framing overhead** | **90 ns (17 %)** | **~100 ns (17 %)** |
+
+Two conclusions fall out:
+
+- **Encode is already near its floor.** 83 % of encode time is the irreducible work of writing the values; the remaining 17 % is the field-key bytes, which *must* be on the wire for a schema-less format. There is no dispatch to remove — the encoder already writes fields straight through in order.
+- **Decode's headroom was the key dispatch.** Before tuning, decode spent over half its time reading each key, hashing it, and routing through a `switch` — the inherent cost of a keyed map. That is what the fast path below targets.
+
+---
+
+## Decode: the positional fast path
+
+A general CBOR map decoder must, per entry, read the key, hash it, and dispatch — the keys could arrive in any order. But in practice they almost always arrive in **struct-declaration order**: qbuem-json's own encoder emits fields in order, and most encoders preserve insertion order.
+
+So the decoder tries a **positional fast path** first. For each field, in declaration order, it confirms the expected next key with a single **non-destructive byte compare** (`CborReader::peek_key_eq`) and, on a match, decodes the value directly — *no hash, no `switch` indirect branch, no separate verify*:
+
+```text
+for each field f in declaration order:
+    if next key (peeked, not consumed) == "f":
+        consume key; decode value into obj.f
+    else:
+        bail → hand this entry and all the rest to the general loop
+```
+
+The first key that does **not** match the expected field flips the fast path off; that entry and every remaining entry fall through to the original hash-`switch` loop. So reordered, foreign, partial, or unknown-key maps decode **exactly** as before — only the common in-order case is accelerated, and the fallback guarantees correctness for everything else.
+
+The peek is a *full* byte compare against the compile-time field name, so it is a complete anti-spoofing check on its own, independent of the hash.
+
+### Supporting micro-architecture
+
+Two smaller changes keep the per-field cost minimal:
+
+- **`read_head` hot/cold split.** The "value `< 24` in the head byte" case (the common one) is ~5 inline instructions; the 1/2/4/8-byte argument tail is moved out-of-line so the inliner folds the hot path into the per-field loop.
+- **Length-only verify for short keys.** For field names ≤ 8 bytes, the key hash *is* the raw little-endian bytes, so a hash match plus an equal length already proves byte-equality — the general-path verify skips a `memcmp`. Names ≥ 9 bytes (where the hash folds and can genuinely collide) keep the full compare.
+
+Multi-byte integer heads and IEEE-754 doubles are read and written with `memcpy` + `__builtin_bswap{32,64}` rather than byte-at-a-time loops, consistent with the library's existing little-endian assumption.
+
+---
+
+## Result
+
+| decode (112 int64 fields) | latency |
+|:---|---:|
+| baseline (general hash dispatch) | ~1110 ns |
+| + hot/cold `read_head`, short-key verify, bswap | ~1005 ns |
+| + positional fast path | **~570 ns** |
+
+The all-scalar case now lands a hair above the **473 ns key-less floor** — i.e. close to the theoretical limit for reading these values at all, while keeping the cross-language map format, full bounds checking, and the spoofing-resistant verify. See [Benchmarks → CBOR](../guide/benchmarks#cbor-binary-codec) for end-to-end numbers and a comparison against other CBOR libraries.
+
+Every byte advance in the decoder is bounds-checked and the recursion depth is capped at 1024, so the same code is safe on untrusted network input — validated by a dedicated libFuzzer target under ASan/UBSan.


### PR DESCRIPTION
## What

The CBOR codec (v1.1.0–v1.1.4) had no presence on the docs site. This adds full coverage and the SEO surfaces, wired into the VitePress nav/sidebar.

### New pages
- **`docs/guide/cbor.md`** — usage: `encode`/`decode`/`encode_to`/`decode_into`, the shared `QBUEM_JSON_FIELDS` registration, supported-type table, **when to use CBOR vs JSON**, C++↔JS (`cbor-x`) cross-language interop, untrusted-input safety.
- **`docs/theory/cbor.md`** — RFC 8949 data model, the definite-length keyed-map wire choice, compile-time key blobs, the **cost decomposition** (value floor vs key-dispatch), and the **positional decode fast path** + fallback.

### Updated
- **`docs/guide/benchmarks.md`** — new **CBOR Binary Codec** section: measured CBOR vs JSON on two game payloads, and qbuem vs nlohmann (**~20× enc / ~28× dec**) vs a hand-written no-reflection ceiling. Clean `{#cbor-binary-codec}` anchor.
- **`docs/.vitepress/config.mts`** — nav "CBOR" entry; sidebar entries (Usage Guide + Engineering Theory); JSON-LD `featureList` + a CBOR FAQ entry + keyword meta (SEO); refreshed displayed version **1.0.8 → 1.1.4** and counts (**572 tests, 12 fuzz targets**).
- **`docs/public/llms.txt` + `llms-full.txt`** — CBOR entries in the AI/LLM index + a full-text CBOR section (API, types, fast path, perf numbers).

## Verification
- VitePress `docs:build` runs clean — **no dead links**, sitemap generated, both new pages render, the `#cbor-binary-codec` anchor resolves.
- `docs/package.json` left at 1.0.5 (npm-ci pin). The pre-existing `guide/debugging.md` "computed is not defined" render warning is untouched and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)