### PR TITLE
feat: rich parse-error context — line/column + format_error (v1.3.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(qbuem_json VERSION 1.2.0 LANGUAGES CXX)
+project(qbuem_json VERSION 1.3.0 LANGUAGES CXX)
 
 # Library Target
 add_library(qbuem_json INTERFACE)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -179,10 +179,10 @@ export default withMermaid(
                         applicationCategory: 'DeveloperApplication',
                         applicationSubCategory: 'C++ Library',
                         operatingSystem: 'Linux, macOS',
-                        version: '1.2.0',
-                        softwareVersion: '1.2.0',
-                        releaseNotes: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.2.0',
-                        downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.2.0',
+                        version: '1.3.0',
+                        softwareVersion: '1.3.0',
+                        releaseNotes: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.3.0',
+                        downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.3.0',
                         installUrl: 'https://qbuem.com/qbuem-json/guide/getting-started',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
                         keywords: 'C++ JSON library, C++20 JSON, fastest JSON parser, SIMD JSON, AVX-512 JSON, zero-allocation JSON, high-performance JSON, HFT JSON, JSON serializer, single header JSON, header-only JSON, CBOR C++, RFC 8949 CBOR, binary serialization C++, nlohmann alternative, simdjson alternative, RapidJSON alternative',
@@ -195,7 +195,8 @@ export default withMermaid(
                             'C++20 concepts-based API',
                             'RFC 8259, RFC 6901, RFC 6902, RFC 8949 compliant',
                             'IEEE 754 round-trip float correctness',
-                            '576 passing tests, 12 libFuzzer targets',
+                            'Rich parse errors: line/column/offset + caret rendering (format_error)',
+                            '583 passing tests, 12 libFuzzer targets',
                             'STL container support (vector, map, optional, tuple, variant)',
                             'Generic/template types via QBUEM_JSON_FIELDS_TPL (one registration, all instantiations)',
                             'Up to 2.9 GB/s parsing, 7.2 GB/s serialization',
@@ -232,7 +233,7 @@ export default withMermaid(
                         },
                         runtimePlatform: 'C++20',
                         targetProduct: { '@id': 'https://qbuem.com/qbuem-json/#application' },
-                        version: '1.2.0',
+                        version: '1.3.0',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
                         keywords: 'C++, JSON, SIMD, AVX-512, High-Performance, HFT, parser, serializer, zero-allocation',
                         author: { '@id': 'https://qbuem.com/#organization' }
@@ -388,9 +389,9 @@ export default withMermaid(
                     ]
                 },
                 {
-                    text: 'v1.2.0',
+                    text: 'v1.3.0',
                     items: [
-                        { text: 'Release Notes', link: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.2.0' },
+                        { text: 'Release Notes', link: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.3.0' },
                         { text: 'All Releases', link: 'https://github.com/qbuem/qbuem-json/releases' }
                     ]
                 }

--- a/docs/guide/errors.md
+++ b/docs/guide/errors.md
@@ -37,24 +37,57 @@ try {
 
 A parse failure throws **`qbuem::parse_error`**. It derives from
 `std::runtime_error` — so existing `catch (const std::runtime_error&)` /
-`catch (const std::exception&)` blocks keep working — and adds an **`offset()`**
-method giving the 0-based byte position in the input where parsing failed (equal
-to the input size when the input ends prematurely):
+`catch (const std::exception&)` blocks keep working — and exposes the full
+failure location: **`offset()`** (0-based byte position), plus **`line()`** and
+**`column()`** (1-based). `what()` reads `"<reason> at line L column C (byte
+offset N)"`.
 
 ```cpp
 try {
     qbuem::Document doc;
     auto root = qbuem::parse(doc, "[1, 2,"); // truncated → throws
 } catch (const qbuem::parse_error& e) {
-    std::cerr << "Parse failed: " << e.what()      // "Invalid JSON at offset 6"
-              << " (byte " << e.offset() << ")\n";  // byte 6
+    std::cerr << e.what() << '\n';        // "Invalid JSON at line 1 column 7 (byte offset 6)"
+    e.line();    // 1
+    e.column();  // 7
+    e.offset();  // 6
 }
 ```
 
 `parse_error` is thrown by every parsing entry point — `parse`, `parse_reuse`,
 `parse_strict`, and the owning `read<T>()` / `fuse<T>()`. On the relaxed scalar
 path `offset()` is the exact failure cursor; on the AVX-512 staged path it is the
-offset just past the last fully consumed value.
+offset just past the last fully consumed value. Line/column are computed only on
+the cold error path (a single pass over the prefix), so the happy path pays
+nothing; for binary inputs (CBOR) `line()`/`column()` are `0`.
+
+### Pretty errors with `format_error`
+
+For human-facing output, **`qbuem::format_error(e, source)`** renders the failing
+line with a caret under the column (the same buffer you parsed must still be
+alive). It falls back to `e.what()` when no location is available.
+
+```cpp
+std::string json = R"({
+  "name": "hero",
+  "score": 3.5.7,
+  "ok": true
+})";
+try {
+    qbuem::read<Config>(json);
+} catch (const qbuem::parse_error& e) {
+    std::cerr << qbuem::format_error(e, json) << '\n';
+}
+```
+
+```text
+Invalid JSON at line 3 column 15 (byte offset 34)
+    "score": 3.5.7,
+                ^
+```
+
+Very long (e.g. minified) lines are windowed around the caret with a leading `…`
+so the message stays readable.
 
 ---
 
@@ -148,7 +181,7 @@ v.type_name();   // "null", "bool", "int", "double", "string", "array", "object"
 
 ## 🔐 Strategy 4: RFC 8259 Strict Validation
 
-Use `qbuem::parse_strict()` or `qbuem::rfc8259::validate()` when you need to enforce strict JSON compliance (e.g., for security-sensitive input processing). Strict failures also throw `qbuem::parse_error`, and `what()` includes both the offset and a human-readable reason.
+Use `qbuem::parse_strict()` or `qbuem::rfc8259::validate()` when you need to enforce strict JSON compliance (e.g., for security-sensitive input processing). Strict failures also throw `qbuem::parse_error` with full line/column/offset, and `what()` includes a human-readable reason.
 
 ```cpp
 #include <qbuem_json/qbuem_json.hpp>
@@ -157,7 +190,7 @@ Use `qbuem::parse_strict()` or `qbuem::rfc8259::validate()` when you need to enf
 try {
     qbuem::rfc8259::validate("[1, 2,]");  // trailing comma → throws
 } catch (const qbuem::parse_error& e) {
-    std::cerr << e.what()        // "RFC 8259 violation at offset 6: trailing comma in array"
+    std::cerr << e.what()        // "RFC 8259 violation at line 1 column 7 (byte offset 6): trailing comma in array"
               << " @ " << e.offset(); // 6
 }
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -418,6 +418,18 @@ if (root["count"].is_int()) {
 int id = root["id"] | -1;
 ```
 
+Parse failures throw qbuem::parse_error (derives from std::runtime_error). It carries offset() (0-based byte), and line()/column() (1-based); what() reads "<reason> at line L column C (byte offset N)". For binary/CBOR errors line()/column() are 0. qbuem::format_error(e, source) renders the failing line with a caret under the column (pass the same buffer you parsed):
+
+```cpp
+try { qbuem::read<Config>(json); }
+catch (const qbuem::parse_error& e) {
+    std::cerr << qbuem::format_error(e, json) << '\n';
+    // Invalid JSON at line 3 column 15 (byte offset 34)
+    //     "score": 3.5.7,
+    //                 ^
+}
+```
+
 ---
 
 ## Third-Party Types (ADL Hooks)

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -22,7 +22,7 @@ Minimum requirements: C++20, GCC 13+ or Clang 18+ or Apple Clang. Supported plat
 - [Custom Allocators](https://qbuem.com/qbuem-json/guide/allocators): Arena allocators, stack allocators, custom memory strategies
 - [Language Bindings](https://qbuem.com/qbuem-json/guide/bindings): C FFI, Python, Rust, Go bindings
 - [Low-Latency Patterns](https://qbuem.com/qbuem-json/guide/low-latency-patterns): HFT tick data patterns, pre-allocated documents, reuse strategies
-- [Correctness & Safety](https://qbuem.com/qbuem-json/guide/correctness): RFC 8259/6901/6902/8949 compliance, IEEE 754 round-trip, 576 tests, sanitizers, fuzzing
+- [Correctness & Safety](https://qbuem.com/qbuem-json/guide/correctness): RFC 8259/6901/6902/8949 compliance, IEEE 754 round-trip, rich parse errors (line/column/caret), 583 tests, sanitizers, fuzzing
 - [Benchmarks](https://qbuem.com/qbuem-json/guide/benchmarks): Live CI benchmark results vs. simdjson, yyjson, RapidJSON, nlohmann
 - [Vision & Roadmap](https://qbuem.com/qbuem-json/guide/vision): Project goals and planned features
 

--- a/include/qbuem_json/qbuem_json.hpp
+++ b/include/qbuem_json/qbuem_json.hpp
@@ -1,7 +1,13 @@
 /**
- * @brief qbuem-json v1.2.0 - High-Performance C++20 JSON Parser
- * @version 1.2.0
+ * @brief qbuem-json v1.3.0 - High-Performance C++20 JSON Parser
+ * @version 1.3.0
  *
+ * v1.3.0: Rich parse-error context (roadmap Tier 1). parse_error now carries
+ *         line() and column() (1-based) in addition to offset(), and what()
+ *         reads "… at line L column C (byte offset N)". New free function
+ *         qbuem::format_error(e, source) renders the failing line with a caret
+ *         under the column (Glaze/serde-style). Location is computed only on the
+ *         cold error path; binary/CBOR errors report line/column 0.
  * v1.2.0: QBUEM_JSON_FIELDS_TPL — register a CLASS TEMPLATE once and every
  *         instantiation gets the full ADL surface (DOM read/write, Nexus fuse,
  *         FastWriter, CBOR encode/decode) as function templates. Pass the
@@ -332,25 +338,58 @@ class SafeValue;
 // prematurely).  what() embeds the same offset for log-only callers.
 class parse_error : public ::std::runtime_error {
 public:
+  // Offset-only (line/column unknown — reported as 0). Kept for backward
+  // compatibility and for binary inputs (e.g. CBOR) where lines are meaningless.
   parse_error(const ::std::string &msg, ::std::size_t offset)
-      : ::std::runtime_error(msg), offset_(offset) {}
+      : ::std::runtime_error(msg), offset_(offset), line_(0), column_(0) {}
+  // Full source location.  line/column are 1-based.
+  parse_error(const ::std::string &msg, ::std::size_t offset,
+              ::std::size_t line, ::std::size_t column)
+      : ::std::runtime_error(msg), offset_(offset), line_(line),
+        column_(column) {}
+  // Byte offset of the failure within the input.
   ::std::size_t offset() const noexcept { return offset_; }
+  // 1-based line / column of the failure, or 0 if not available (binary input).
+  ::std::size_t line() const noexcept { return line_; }
+  ::std::size_t column() const noexcept { return column_; }
 
 private:
   ::std::size_t offset_;
+  ::std::size_t line_;
+  ::std::size_t column_;
 };
 
-// Build "<msg> at offset N" and throw parse_error.  failpos is clamped into the
-// input; a null failpos (no position available) reports the end of input.
+// 1-based (line, column) of byte `off` within `src`.  Column counts bytes (not
+// code points), which matches the offset and keeps the scan branch-light.  A
+// single forward pass — cold path (only runs when an error is being thrown).
+struct source_position {
+  ::std::size_t offset;
+  ::std::size_t line;
+  ::std::size_t column;
+};
+inline source_position compute_source_position(::std::string_view src,
+                                               ::std::size_t off) noexcept {
+  if (off > src.size()) off = src.size();
+  ::std::size_t line = 1, line_start = 0;
+  for (::std::size_t i = 0; i < off; ++i)
+    if (src[i] == '\n') { ++line; line_start = i + 1; }
+  return {off, line, off - line_start + 1};
+}
+
+// Build "<msg> at line L column C (byte N)" and throw parse_error with the full
+// location.  failpos is clamped into the input; a null failpos (no position
+// available) reports the end of input.
 [[noreturn]] inline void throw_parse_error(const char *msg, const char *failpos,
                                            ::std::string_view json) {
   ::std::size_t off = json.size();
   if (failpos && failpos >= json.data() &&
       failpos <= json.data() + json.size())
     off = static_cast<::std::size_t>(failpos - json.data());
-  char buf[96];
-  ::std::snprintf(buf, sizeof(buf), "%s at offset %zu", msg, off);
-  throw parse_error(buf, off);
+  const source_position loc = compute_source_position(json, off);
+  char buf[128];
+  ::std::snprintf(buf, sizeof(buf), "%s at line %zu column %zu (byte offset %zu)",
+                  msg, loc.line, loc.column, loc.offset);
+  throw parse_error(buf, loc.offset, loc.line, loc.column);
 }
 
 // Require C++20 for optimal constexpr, bit_cast, and concepts
@@ -7804,13 +7843,18 @@ namespace detail_ {
 [[noreturn]] inline void fail(const char *msg, const char *pos,
                               const char *begin) {
   const size_t off = static_cast<size_t>(pos - begin);
-  char buf[128];
-  std::snprintf(buf, sizeof(buf), "RFC 8259 violation at offset %zu: %s", off,
-                msg);
+  // The prefix [begin, begin+off) is exactly the input up to the failure, so its
+  // end position is the failure's line/column.
+  const ::qbuem::json::source_position loc =
+      ::qbuem::json::compute_source_position(::std::string_view(begin, off), off);
+  char buf[160];
+  std::snprintf(buf, sizeof(buf),
+                "RFC 8259 violation at line %zu column %zu (byte offset %zu): %s",
+                loc.line, loc.column, off, msg);
   // parse_error (derived from std::runtime_error) so strict-mode failures carry
-  // the same typed offset() as the relaxed parser; existing catch blocks for
-  // std::runtime_error / std::exception are unaffected.
-  throw ::qbuem::json::parse_error(buf, off);
+  // the same typed offset()/line()/column() as the relaxed parser; existing
+  // catch blocks for std::runtime_error / std::exception are unaffected.
+  throw ::qbuem::json::parse_error(buf, off, loc.line, loc.column);
 }
 
 struct Validator {
@@ -9538,7 +9582,63 @@ using Parser = json::Parser;
 using Document = json::DocumentView;
 using Value = json::Value;
 using SafeValue = json::SafeValue;
-using parse_error = json::parse_error; // thrown by parse*/read/fuse; has offset()
+using parse_error = json::parse_error; // thrown by parse*/read/fuse; offset()/line()/column()
+
+// format_error(e, source) — render a parse_error against its original source as a
+// human-readable, multi-line message: the failing line plus a caret under the
+// column. `source` must be the same buffer that was parsed; if the error carries
+// no line info (e.g. a binary/CBOR error) or `source` is empty, returns e.what().
+//
+//   try { qbuem::read<T>(json); }
+//   catch (const qbuem::parse_error& e) { std::cerr << qbuem::format_error(e, json) << '\n'; }
+//
+//   Invalid JSON at line 3 column 14 (byte 42)
+//     "score": 3.5.7,
+//                ^
+inline ::std::string format_error(const parse_error &e,
+                                  ::std::string_view source) {
+  ::std::string out = e.what();
+  const ::std::size_t line = e.line();
+  if (line == 0 || source.empty()) return out; // no positional context
+
+  // Locate the [start, stop) byte range of the offending line.
+  ::std::size_t start = 0;
+  for (::std::size_t cur = 1; cur < line; ++cur) {
+    const ::std::size_t nl = source.find('\n', start);
+    if (nl == ::std::string_view::npos) { start = source.size(); break; }
+    start = nl + 1;
+  }
+  ::std::size_t stop = source.find('\n', start);
+  if (stop == ::std::string_view::npos) stop = source.size();
+  if (stop > start && source[stop - 1] == '\r') --stop; // trim CR of CRLF
+  ::std::string_view text = source.substr(start, stop - start);
+
+  // 0-based caret column within the line; clamp into the (possibly windowed) line.
+  ::std::size_t caret = e.column() ? e.column() - 1 : 0;
+
+  // Window very long lines so a minified blob doesn't dump everything: keep ~100
+  // bytes around the caret, marking elision with a leading "…".
+  constexpr ::std::size_t kWindow = 100;
+  ::std::string prefix;
+  if (text.size() > kWindow && caret > 40) {
+    const ::std::size_t from = caret - 40;
+    text = text.substr(from, kWindow);
+    caret -= from;
+    prefix = "…";
+  } else if (text.size() > kWindow) {
+    text = text.substr(0, kWindow);
+  }
+  if (caret > text.size()) caret = text.size();
+
+  out += '\n';
+  out += "  ";
+  out += prefix;
+  out.append(text.data(), text.size());
+  out += "\n  ";
+  out.append(prefix.size() + caret, ' ');
+  out += '^';
+  return out;
+}
 
 namespace rfc8259 = json::rfc8259;
 

--- a/tests/test_errors.cpp
+++ b/tests/test_errors.cpp
@@ -53,3 +53,76 @@ TEST(ErrorHandling, UnbalancedDepth) {
   EXPECT_FALSE(dom_ok("{\"a\":1"));
   EXPECT_FALSE(dom_ok("{\"key\":\"value\""));
 }
+
+// ── Rich error context: line / column / caret (v1.3) ─────────────────────────
+
+// Catch a parse_error and return it, or nullopt-style sentinel via flag.
+static bool catch_parse_error(std::string_view j, qbuem::parse_error &out) {
+  try {
+    Document doc;
+    parse(doc, j);
+    return false;
+  } catch (const qbuem::parse_error &e) {
+    out = e;
+    return true;
+  }
+}
+
+TEST(ErrorContext, LineColumnOnMultilineInput) {
+  // Error (@) sits on the 3rd line.
+  const std::string j = "{\n  \"a\": 1,\n  \"b\": @\n}";
+  qbuem::parse_error e("", 0);
+  ASSERT_TRUE(catch_parse_error(j, e));
+  EXPECT_EQ(e.line(), 3u);          // newline count is deterministic
+  EXPECT_GE(e.column(), 1u);
+  EXPECT_LT(e.offset(), j.size());
+}
+
+TEST(ErrorContext, SingleLineIsLineOne) {
+  qbuem::parse_error e("", 0);
+  ASSERT_TRUE(catch_parse_error("[1, 2, @]", e));
+  EXPECT_EQ(e.line(), 1u);
+  EXPECT_GE(e.column(), 1u);
+}
+
+TEST(ErrorContext, OffsetStillReported) {
+  // Backward-compat: offset() remains valid.
+  qbuem::parse_error e("", 0);
+  ASSERT_TRUE(catch_parse_error("{\"x\": tru}", e));
+  EXPECT_GT(e.offset(), 0u);
+}
+
+TEST(ErrorContext, WhatMentionsLineColumn) {
+  qbuem::parse_error e("", 0);
+  ASSERT_TRUE(catch_parse_error("{\n  bad\n}", e));
+  const std::string what = e.what();
+  EXPECT_NE(what.find("line"), std::string::npos);
+  EXPECT_NE(what.find("column"), std::string::npos);
+}
+
+TEST(ErrorContext, FormatErrorShowsCaret) {
+  const std::string j = "{\n  \"a\": 1,\n  \"b\": @\n}";
+  qbuem::parse_error e("", 0);
+  ASSERT_TRUE(catch_parse_error(j, e));
+  const std::string rendered = qbuem::format_error(e, j);
+  EXPECT_NE(rendered.find('^'), std::string::npos);     // caret present
+  EXPECT_NE(rendered.find("\"b\""), std::string::npos);  // offending line shown
+}
+
+TEST(ErrorContext, FormatErrorNoLocationFallsBack) {
+  // A bare offset-only error (line == 0) renders as what(), no caret.
+  qbuem::parse_error e("synthetic", 5);
+  EXPECT_EQ(qbuem::format_error(e, "whatever"), std::string("synthetic"));
+}
+
+TEST(ErrorContext, FormatErrorWindowsLongLine) {
+  // A very long single line must not crash and must still carry a caret.
+  std::string j = "[";
+  j.append(400, '1');
+  j += " @]"; // invalid token far along the line
+  qbuem::parse_error e("", 0);
+  ASSERT_TRUE(catch_parse_error(j, e));
+  const std::string rendered = qbuem::format_error(e, j);
+  EXPECT_NE(rendered.find('^'), std::string::npos);
+  EXPECT_LT(rendered.size(), j.size());                 // windowed, not the whole blob
+}


### PR DESCRIPTION
**Roadmap Tier 1 #1.** Closes the verified DX gap: `parse_error` carried only a byte `offset()`; the bar set by Glaze/serde_json is **line:column + a caret**. All on the cold error path — happy path unchanged.

## API
- `parse_error::line()` / `column()` — 1-based (0 when unavailable, e.g. binary/CBOR). New 4-arg ctor; the old offset-only ctor stays for back-compat. `what()` → `"<reason> at line L column C (byte offset N)"`.
- **`qbuem::format_error(e, source)`** — renders the failing line with a caret under the column; falls back to `e.what()` when no location; windows long/minified lines around the caret.

```text
Invalid JSON at line 3 column 15 (byte offset 34)
    "score": 3.5.7,
                ^
```

Wired into the DOM (`throw_parse_error`) and `rfc8259::validate` paths. Kept the literal "offset" in messages so the existing message-substring test still matches.

## Verification
- 7 new `ErrorContext` tests (line/col multi- & single-line, offset back-compat, `what()` wording, caret, no-location fallback, long-line windowing).
- **583/583** pass (Release + ASan/UBSan); CBOR fuzz **8M iters clean**.
- Docs: `guide/errors.md`, `llms.txt`/`llms-full.txt`, SEO featureList; version **1.2.0 → 1.3.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)