### PR TITLE
feat: enum support — integer default + QBUEM_JSON_ENUM value names (v1.4.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(qbuem_json VERSION 1.3.0 LANGUAGES CXX)
+project(qbuem_json VERSION 1.4.0 LANGUAGES CXX)
 
 # Library Target
 add_library(qbuem_json INTERFACE)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -179,10 +179,10 @@ export default withMermaid(
                         applicationCategory: 'DeveloperApplication',
                         applicationSubCategory: 'C++ Library',
                         operatingSystem: 'Linux, macOS',
-                        version: '1.3.0',
-                        softwareVersion: '1.3.0',
-                        releaseNotes: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.3.0',
-                        downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.3.0',
+                        version: '1.4.0',
+                        softwareVersion: '1.4.0',
+                        releaseNotes: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.4.0',
+                        downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.4.0',
                         installUrl: 'https://qbuem.com/qbuem-json/guide/getting-started',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
                         keywords: 'C++ JSON library, C++20 JSON, fastest JSON parser, SIMD JSON, AVX-512 JSON, zero-allocation JSON, high-performance JSON, HFT JSON, JSON serializer, single header JSON, header-only JSON, CBOR C++, RFC 8949 CBOR, binary serialization C++, nlohmann alternative, simdjson alternative, RapidJSON alternative',
@@ -196,8 +196,9 @@ export default withMermaid(
                             'RFC 8259, RFC 6901, RFC 6902, RFC 8949 compliant',
                             'IEEE 754 round-trip float correctness',
                             'Rich parse errors: line/column/offset + caret rendering (format_error)',
-                            '583 passing tests, 12 libFuzzer targets',
+                            '591 passing tests, 12 libFuzzer targets',
                             'STL container support (vector, map, optional, tuple, variant)',
+                            'Enum support: integer by default, value-name via QBUEM_JSON_ENUM (JSON + CBOR)',
                             'Generic/template types via QBUEM_JSON_FIELDS_TPL (one registration, all instantiations)',
                             'Up to 2.9 GB/s parsing, 7.2 GB/s serialization',
                             'Apache 2.0 license — free for commercial use',
@@ -233,7 +234,7 @@ export default withMermaid(
                         },
                         runtimePlatform: 'C++20',
                         targetProduct: { '@id': 'https://qbuem.com/qbuem-json/#application' },
-                        version: '1.3.0',
+                        version: '1.4.0',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
                         keywords: 'C++, JSON, SIMD, AVX-512, High-Performance, HFT, parser, serializer, zero-allocation',
                         author: { '@id': 'https://qbuem.com/#organization' }
@@ -389,9 +390,9 @@ export default withMermaid(
                     ]
                 },
                 {
-                    text: 'v1.3.0',
+                    text: 'v1.4.0',
                     items: [
-                        { text: 'Release Notes', link: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.3.0' },
+                        { text: 'Release Notes', link: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.4.0' },
                         { text: 'All Releases', link: 'https://github.com/qbuem/qbuem-json/releases' }
                     ]
                 }

--- a/docs/guide/mapping.md
+++ b/docs/guide/mapping.md
@@ -141,6 +141,42 @@ It emits the same ADL surface as `QBUEM_JSON_FIELDS` (DOM `read`/`write`, Nexus 
 - The parentheses around the two type arguments are required; they are what lets multi-parameter templates (`(Pair<A, B>)`) pass through the preprocessor. A bare `QBUEM_JSON_FIELDS(Pair<int, std::string>, …)` does **not** compile because the preprocessor splits on the comma inside `<…>` — wrap multi-param instantiations in a `using` alias, or use `QBUEM_JSON_FIELDS_TPL`.
 :::
 
+### Enums {#enums}
+
+Any `enum` / `enum class` works out of the box, serializing as its **underlying
+integer** across every engine (DOM, `fuse`, CBOR):
+
+```cpp
+enum class Dir { North, East, South, West };
+struct Mob { int id; Dir facing; };
+QBUEM_JSON_FIELDS(Mob, id, facing)
+
+qbuem::write(Mob{7, Dir::West});   // {"id":7,"facing":3}
+```
+
+To serialize an enum as its **value name** instead, register it once with
+`QBUEM_JSON_ENUM` (at the enum's namespace scope, like `QBUEM_JSON_FIELDS`):
+
+```cpp
+enum class Color { Red, Green, Blue };
+QBUEM_JSON_ENUM(Color, Red, Green, Blue)
+
+qbuem::write(Color::Green);                 // "Green"
+qbuem::read<Color>("\"Blue\"");             // Color::Blue
+qbuem::cbor::encode(Color::Red);            // CBOR text "Red"
+```
+
+It round-trips by name across JSON, `fuse`, and CBOR. On read, an unknown name
+leaves the field at its default (DOM) or throws `qbuem::parse_error` (CBOR /
+strict `fuse`). The names are the C++ enumerator identifiers; for custom wire
+strings, define the two ADL hooks yourself (`qbuem_enum_to_string(E)` and
+`qbuem_enum_from_string(std::string_view, E&)`).
+
+> [!NOTE] Default values are automatic
+> When a registered field's key is **absent** from the input object, qbuem-json
+> leaves that field at its default — no annotation needed. So a missing `"facing"`
+> keeps whatever the struct's default-initialized `Dir` is.
+
 ---
 
 ## ✏️ Mutating Parsed JSON

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -275,6 +275,15 @@ template <typename A, typename B> struct Pair { A a; B b; };
 QBUEM_JSON_FIELDS_TPL((typename A, typename B), (Pair<A, B>), a, b) // any Pair<A,B>
 ```
 
+Enums: any enum/enum class serializes as its underlying integer by default (DOM, fuse, CBOR). Register with QBUEM_JSON_ENUM to serialize as the value name instead; it round-trips by name across JSON and CBOR. Absent object keys leave a field at its default (no annotation needed).
+
+```cpp
+enum class Color { Red, Green, Blue };
+QBUEM_JSON_ENUM(Color, Red, Green, Blue)   // at the enum's namespace scope
+qbuem::write(Color::Green);                 // "Green"
+qbuem::read<Color>("\"Blue\"");             // Color::Blue
+```
+
 QBUEM_JSON_FIELDS_TPL has zero runtime overhead: the compiler instantiates the templates to the same machine code as a concrete QBUEM_JSON_FIELDS registration. Measured on a structurally-identical 7-field type, encode/decode/fuse latency matched within noise (<=0.5%) and the emitted JSON and CBOR bytes were byte-for-byte identical. It is a pure compile-time convenience.
 
 ---

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -22,7 +22,7 @@ Minimum requirements: C++20, GCC 13+ or Clang 18+ or Apple Clang. Supported plat
 - [Custom Allocators](https://qbuem.com/qbuem-json/guide/allocators): Arena allocators, stack allocators, custom memory strategies
 - [Language Bindings](https://qbuem.com/qbuem-json/guide/bindings): C FFI, Python, Rust, Go bindings
 - [Low-Latency Patterns](https://qbuem.com/qbuem-json/guide/low-latency-patterns): HFT tick data patterns, pre-allocated documents, reuse strategies
-- [Correctness & Safety](https://qbuem.com/qbuem-json/guide/correctness): RFC 8259/6901/6902/8949 compliance, IEEE 754 round-trip, rich parse errors (line/column/caret), 583 tests, sanitizers, fuzzing
+- [Correctness & Safety](https://qbuem.com/qbuem-json/guide/correctness): RFC 8259/6901/6902/8949 compliance, IEEE 754 round-trip, rich parse errors (line/column/caret), enum support, 591 tests, sanitizers, fuzzing
 - [Benchmarks](https://qbuem.com/qbuem-json/guide/benchmarks): Live CI benchmark results vs. simdjson, yyjson, RapidJSON, nlohmann
 - [Vision & Roadmap](https://qbuem.com/qbuem-json/guide/vision): Project goals and planned features
 

--- a/fuzz/fuzz_cbor.cpp
+++ b/fuzz/fuzz_cbor.cpp
@@ -16,11 +16,17 @@
 #include <tuple>
 #include <vector>
 
+enum class CborTier : uint8_t { Free, Lite, Premium };   // integer enum
+enum class CborColor { Red, Green, Blue };               // string-mapped enum
+QBUEM_JSON_ENUM(CborColor, Red, Green, Blue)
+
 struct CborNested {
   int64_t id;
   std::string name;
+  CborTier tier;
+  CborColor color;
 };
-QBUEM_JSON_FIELDS(CborNested, id, name)
+QBUEM_JSON_FIELDS(CborNested, id, name, tier, color)
 
 struct CborFuzz {
   int64_t i;

--- a/include/qbuem_json/qbuem_json.hpp
+++ b/include/qbuem_json/qbuem_json.hpp
@@ -1,6 +1,13 @@
 /**
- * @brief qbuem-json v1.3.0 - High-Performance C++20 JSON Parser
- * @version 1.3.0
+ * @brief qbuem-json v1.4.0 - High-Performance C++20 JSON Parser
+ * @version 1.4.0
+ *
+ * v1.4.0: Enum support (roadmap Tier 1). Any enum/enum class now serializes out
+ *         of the box as its underlying integer across every engine (DOM, fuse,
+ *         CBOR). Opt into a string representation with QBUEM_JSON_ENUM(E, A, B,
+ *         …): the value round-trips as its enumerator name (JSON string / CBOR
+ *         text). Absent object keys already leave a field at its default, so
+ *         "default value on read" needs no annotation.
  *
  * v1.3.0: Rich parse-error context (roadmap Tier 1). parse_error now carries
  *         line() and column() (1-based) in addition to offset(), and what()
@@ -8304,6 +8311,21 @@ concept HasNexusPulseH = requires(uint64_t h, ::std::string_view key,
   nexus_pulse_h(h, key, p, end, t);
 };
 
+// ── Enum support ─────────────────────────────────────────────────────────────
+// Any `enum`/`enum class` serializes out of the box as its underlying integer.
+// Opt into a string representation with QBUEM_JSON_ENUM(E, A, B, ...): it
+// generates ADL hooks `qbuem_enum_to_string(E)` / `qbuem_enum_from_string(sv, E&)`
+// in the enum's namespace, and then the value round-trips as its name across
+// every engine (DOM, fuse, CBOR).  Detection is by ADL (same mechanism as
+// QBUEM_JSON_FIELDS), so the macro is invoked at the enum's namespace scope.
+template <typename E>
+concept JsonDetailStringEnum =
+    std::is_enum_v<E> &&
+    requires(E e, ::std::string_view s, E &er) {
+      { qbuem_enum_to_string(e) } -> ::std::convertible_to<::std::string_view>;
+      qbuem_enum_from_string(s, er);
+    };
+
 // ── Forward declarations
 
 template <typename T> void from_json(const Value &v, T &out);
@@ -8371,6 +8393,13 @@ template <typename T> void from_json(const Value &v, T &out) {
     // nothing — null is null
   } else if constexpr (JsonDetailBool<T>) {
     out = v.as<bool>();
+  } else if constexpr (std::is_enum_v<T>) {
+    if constexpr (JsonDetailStringEnum<T>) {
+      T tmp{};
+      if (qbuem_enum_from_string(v.template as<std::string_view>(), tmp)) out = tmp;
+    } else {
+      out = static_cast<T>(v.template as<std::underlying_type_t<T>>());
+    }
   } else if constexpr (JsonDetailArith<T>) {
     out = v.as<T>();
   } else if constexpr (std::is_same_v<T, std::string>) {
@@ -8431,6 +8460,11 @@ template <typename T> std::string to_json_str(const T &in) {
     return "null";
   } else if constexpr (JsonDetailBool<T>) {
     return in ? "true" : "false";
+  } else if constexpr (std::is_enum_v<T>) {
+    if constexpr (JsonDetailStringEnum<T>)
+      return to_json_str(std::string_view(qbuem_enum_to_string(in)));
+    else
+      return to_json_str(static_cast<std::underlying_type_t<T>>(in));
   } else if constexpr (std::is_integral_v<T>) {
     char buf[24];
     char *p;
@@ -8611,6 +8645,11 @@ template <typename W, typename T> void append_json(W &out, const T &in) {
     json_write(out, "null", 4);
   } else if constexpr (JsonDetailBool<T>) {
     if (in) json_write(out, "true", 4); else json_write(out, "false", 5);
+  } else if constexpr (std::is_enum_v<T>) {
+    if constexpr (JsonDetailStringEnum<T>)
+      append_json(out, std::string_view(qbuem_enum_to_string(in)));
+    else
+      append_json(out, static_cast<std::underlying_type_t<T>>(in));
   } else if constexpr (std::is_integral_v<T>) {
     char buf[24];
     char *ep;
@@ -8832,6 +8871,11 @@ template <typename W, typename T> void append_cbor(W &out, const T &in) {
     json_put(out, static_cast<char>(0xf6)); // null
   } else if constexpr (JsonDetailBool<T>) {
     json_put(out, static_cast<char>(in ? 0xf5 : 0xf4)); // true / false
+  } else if constexpr (std::is_enum_v<T>) {
+    if constexpr (JsonDetailStringEnum<T>)
+      append_cbor(out, std::string_view(qbuem_enum_to_string(in)));  // text
+    else
+      append_cbor(out, static_cast<std::underlying_type_t<T>>(in));   // integer
   } else if constexpr (std::is_integral_v<T>) {
     if constexpr (std::is_unsigned_v<T>) {
       cbor_head(out, 0, static_cast<uint64_t>(in));
@@ -9132,6 +9176,17 @@ template <typename T> void from_cbor(CborReader &cr, T &out) {
     cr.read_null();
   } else if constexpr (JsonDetailBool<T>) {
     out = cr.read_bool();
+  } else if constexpr (std::is_enum_v<T>) {
+    if constexpr (JsonDetailStringEnum<T>) {
+      T tmp{};
+      if (!qbuem_enum_from_string(cr.read_text(), tmp))
+        cr.fail("CBOR: unknown enum string");
+      out = tmp;
+    } else {
+      std::underlying_type_t<T> u{};
+      from_cbor(cr, u);
+      out = static_cast<T>(u);
+    }
   } else if constexpr (std::is_integral_v<T>) {
     uint8_t mt; uint64_t arg = cr.read_head(mt);
     if (mt == 0)      out = static_cast<T>(arg);               // unsigned: exact
@@ -9547,6 +9602,41 @@ inline void to_json_field(Value &obj, const char *key, const T &val) {
     if (_bindef) _cr.consume_break();                                          \
   }
 
+// ============================================================================
+// QBUEM_JSON_ENUM — serialize an enum as its value name (string) everywhere
+// ============================================================================
+//
+// Without this, an enum serializes as its underlying integer (works out of the
+// box). With it, the enum round-trips as the value name across every engine
+// (DOM, fuse, CBOR). Invoke at the enum's namespace scope (ADL), like
+// QBUEM_JSON_FIELDS:
+//
+//   enum class Color { Red, Green, Blue };
+//   QBUEM_JSON_ENUM(Color, Red, Green, Blue)
+//
+// Unknown strings: on read they leave the field unchanged (DOM) / throw
+// (CBOR / strict fuse). Names are the C++ enumerator identifiers; for custom
+// wire strings, write the two hooks by hand (qbuem_enum_to_string /
+// qbuem_enum_from_string).
+#define QBUEM_JSON_DETAIL_ENUM_TO(A)   case _qb_enum_t::A: return #A;
+#define QBUEM_JSON_DETAIL_ENUM_FROM(A)                                         \
+  if (_qb_s == ::std::string_view(#A)) { _qb_e = _qb_enum_t::A; return true; }
+
+#define QBUEM_JSON_ENUM(EnumType, ...)                                         \
+  inline ::std::string_view qbuem_enum_to_string(EnumType _qb_v) noexcept {    \
+    using _qb_enum_t = EnumType;                                              \
+    switch (_qb_v) {                                                          \
+      QBUEM_FOR_EACH(QBUEM_JSON_DETAIL_ENUM_TO, __VA_ARGS__)                   \
+    }                                                                          \
+    return {};                                                                \
+  }                                                                            \
+  inline bool qbuem_enum_from_string(::std::string_view _qb_s,                 \
+                                     EnumType &_qb_e) noexcept {               \
+    using _qb_enum_t = EnumType;                                              \
+    QBUEM_FOR_EACH(QBUEM_JSON_DETAIL_ENUM_FROM, __VA_ARGS__)                   \
+    return false;                                                              \
+  }
+
 
 } // namespace json
 } // namespace qbuem
@@ -9945,6 +10035,18 @@ template <typename T> void from_json_direct(const char *&p, const char *end, T &
     else {
       if (nexus_strict_mode()) nexus_type_error("boolean", p, end);
       else skip_direct(p, end);
+    }
+  } else if constexpr (std::is_enum_v<T>) {
+    if constexpr (JsonDetailStringEnum<T>) {
+      std::string tmp;
+      from_json_direct(p, end, tmp);  // reuse the std::string token reader
+      T e{};
+      if (qbuem_enum_from_string(tmp, e)) out = e;
+      else if (nexus_strict_mode()) nexus_type_error("enum", p, end);
+    } else {
+      std::underlying_type_t<T> u{};
+      from_json_direct(p, end, u);    // reuse the integer reader
+      out = static_cast<T>(u);
     }
   } else if constexpr (JsonDetailArith<T>) {
     while (p < end && (unsigned char)*p <= 32) ++p;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -71,6 +71,7 @@ add_qbuem_gtest(test_duplicate_keys)
 add_qbuem_gtest(test_serializer)
 add_qbuem_gtest(test_errors)
 add_qbuem_gtest(test_cbor)
+add_qbuem_gtest(test_enum)
 
 # ── New: dom API type coverage and round-trip fidelity ────────────────────
 add_qbuem_gtest(test_dom_types)

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -1,0 +1,106 @@
+// Enum support (roadmap Tier 1): an enum serializes as its underlying integer by
+// default, or as its value name when registered with QBUEM_JSON_ENUM — across
+// every engine (DOM read/write, fuse, CBOR).
+#include <gtest/gtest.h>
+
+#include "qbuem_json/qbuem_json.hpp"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+// Integer enum (no registration) — encodes as the underlying value.
+enum class Dir : int { North = 0, East = 1, South = 2, West = 3 };
+
+// Small underlying type, to confirm the cast path is width-correct.
+enum class Tier : std::uint8_t { Free = 0, Lite = 1, Premium = 2 };
+
+// String-mapped enum (opt-in).
+enum class Color { Red, Green, Blue };
+QBUEM_JSON_ENUM(Color, Red, Green, Blue)
+
+struct Item {
+  int64_t id;
+  Color color;            // string
+  Dir facing;             // integer
+  std::optional<Color> accent;
+  std::vector<Color> palette;
+};
+QBUEM_JSON_FIELDS(Item, id, color, facing, accent, palette)
+
+TEST(Enum, IntegerEnumDefaultEncoding) {
+  // fuse() is for structs; bare-scalar round-trips use DOM/CBOR. The enum-in-
+  // struct fuse path is covered by NestedInStructAllEngines below.
+  EXPECT_EQ(qbuem::write(Dir::West), "3");
+  EXPECT_EQ(qbuem::read<Dir>("2"), Dir::South);
+  EXPECT_EQ(qbuem::cbor::decode<Dir>(qbuem::cbor::encode(Dir::South)), Dir::South);
+}
+
+TEST(Enum, SmallUnderlyingType) {
+  EXPECT_EQ(qbuem::write(Tier::Premium), "2");
+  EXPECT_EQ(qbuem::cbor::decode<Tier>(qbuem::cbor::encode(Tier::Lite)), Tier::Lite);
+}
+
+TEST(Enum, StringEnumName) {
+  EXPECT_EQ(qbuem::write(Color::Green), "\"Green\"");
+  EXPECT_EQ(qbuem::read<Color>("\"Blue\""), Color::Blue);
+}
+
+TEST(Enum, StringEnumCborIsText) {
+  std::string bytes = qbuem::cbor::encode(Color::Blue);
+  ASSERT_FALSE(bytes.empty());
+  EXPECT_EQ((uint8_t)bytes[0] >> 5, 3u); // CBOR major type 3 = text string
+  EXPECT_EQ(qbuem::cbor::decode<Color>(bytes), Color::Blue);
+}
+
+TEST(Enum, NestedInStructAllEngines) {
+  Item in{ 7, Color::Green, Dir::West, Color::Red, { Color::Blue, Color::Green } };
+
+  const std::string j = qbuem::write(in);
+  EXPECT_NE(j.find("\"color\":\"Green\""), std::string::npos);
+  EXPECT_NE(j.find("\"facing\":3"), std::string::npos);
+  EXPECT_NE(j.find("\"accent\":\"Red\""), std::string::npos);
+
+  auto dom = qbuem::read<Item>(j);
+  EXPECT_EQ(dom.color, Color::Green);
+  EXPECT_EQ(dom.facing, Dir::West);
+  ASSERT_TRUE(dom.accent.has_value());
+  EXPECT_EQ(*dom.accent, Color::Red);
+  EXPECT_EQ(dom.palette, (std::vector<Color>{ Color::Blue, Color::Green }));
+
+  auto fus = qbuem::fuse<Item>(j);
+  EXPECT_EQ(fus.color, Color::Green);
+  EXPECT_EQ(fus.palette.size(), 2u);
+
+  auto cb = qbuem::cbor::decode<Item>(qbuem::cbor::encode(in));
+  EXPECT_EQ(cb.color, Color::Green);
+  EXPECT_EQ(cb.facing, Dir::West);
+  ASSERT_TRUE(cb.accent.has_value());
+  EXPECT_EQ(*cb.accent, Color::Red);
+  EXPECT_EQ(cb.palette[0], Color::Blue);
+}
+
+TEST(Enum, OptionalNulloptStringEnum) {
+  Item in{ 1, Color::Red, Dir::North, std::nullopt, {} };
+  auto cb = qbuem::cbor::decode<Item>(qbuem::cbor::encode(in));
+  EXPECT_FALSE(cb.accent.has_value());
+  auto dom = qbuem::read<Item>(qbuem::write(in));
+  EXPECT_FALSE(dom.accent.has_value());
+}
+
+TEST(Enum, UnknownStringOnCborThrows) {
+  // A text string that maps to no enumerator must throw, not silently corrupt.
+  std::string bad;
+  bad.push_back((char)0x64);           // text(4)
+  bad += "Cyan";                        // not a Color
+  EXPECT_THROW((void)qbuem::cbor::decode<Color>(bad), qbuem::parse_error);
+}
+
+TEST(Enum, UnknownStringOnDomLeavesDefault) {
+  // DOM read of an unknown name leaves the field at its prior/default value.
+  Color c = Color::Green;
+  c = qbuem::read<Color>("\"Cyan\""); // unknown → unchanged from a fresh default
+  // read<T> default-constructs first (Color{} == Red), then leaves it on miss.
+  EXPECT_EQ(c, Color{});
+}


### PR DESCRIPTION
**Roadmap Tier 1 #2** (serde-style attributes). Enums previously hit the no-codec `static_assert`. Now they work across **every engine**.

## Behavior
- **Default:** any `enum` / `enum class` serializes as its **underlying integer** (DOM, `fuse`, CBOR). One `std::is_enum_v` branch per type-dispatch site (`from_json`, `to_json_str`, `append_json`, `append_cbor`, `from_cbor`, `from_json_direct`), each **reusing the existing integer/string paths by recursion** — no duplicated parsing, zero cost for non-enums.
- **Opt-in string names:** `QBUEM_JSON_ENUM(E, A, B, …)` → the value round-trips as its enumerator name (JSON string / CBOR text) across DOM, `fuse`, and CBOR.

```cpp
enum class Color { Red, Green, Blue };
QBUEM_JSON_ENUM(Color, Red, Green, Blue)

qbuem::write(Color::Green);       // "Green"
qbuem::read<Color>("\"Blue\"");   // Color::Blue
qbuem::cbor::encode(Color::Red);  // CBOR text "Red"
```

Generates ADL hooks (`qbuem_enum_to_string` / `qbuem_enum_from_string`) in the enum's namespace — same ADL mechanism + invocation rule as `QBUEM_JSON_FIELDS`; detection is a concept so the integer path stays the default. Unknown name on read → field unchanged (DOM) or `parse_error` (CBOR / strict `fuse`). Custom wire strings: define the two hooks by hand.

**Default values** needed no code — an absent object key already leaves the field at its default (`from_json_field` early-returns). Documented.

## Verification
- `tests/test_enum.cpp` (8): integer default + small underlying type, string name, CBOR-text encoding, nested-in-struct across all engines, optional/nullopt, unknown-string throws (CBOR) / leaves default (DOM).
- **591/591** pass (Release + ASan/UBSan).
- `fuzz_cbor` gains an integer enum + a string enum field; **8M-iter ASan/UBSan clean**.
- Docs: `guide/mapping.md` "Enums" section, `llms.txt`/`llms-full.txt`, SEO; version **1.3.0 → 1.4.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)