### PR TITLE
feat: field rename (member, "jsonKey") + skip-by-omission (v1.5.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(qbuem_json VERSION 1.4.0 LANGUAGES CXX)
+project(qbuem_json VERSION 1.5.0 LANGUAGES CXX)
 
 # Library Target
 add_library(qbuem_json INTERFACE)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -179,10 +179,10 @@ export default withMermaid(
                         applicationCategory: 'DeveloperApplication',
                         applicationSubCategory: 'C++ Library',
                         operatingSystem: 'Linux, macOS',
-                        version: '1.4.0',
-                        softwareVersion: '1.4.0',
-                        releaseNotes: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.4.0',
-                        downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.4.0',
+                        version: '1.5.0',
+                        softwareVersion: '1.5.0',
+                        releaseNotes: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.5.0',
+                        downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.5.0',
                         installUrl: 'https://qbuem.com/qbuem-json/guide/getting-started',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
                         keywords: 'C++ JSON library, C++20 JSON, fastest JSON parser, SIMD JSON, AVX-512 JSON, zero-allocation JSON, high-performance JSON, HFT JSON, JSON serializer, single header JSON, header-only JSON, CBOR C++, RFC 8949 CBOR, binary serialization C++, nlohmann alternative, simdjson alternative, RapidJSON alternative',
@@ -196,9 +196,10 @@ export default withMermaid(
                             'RFC 8259, RFC 6901, RFC 6902, RFC 8949 compliant',
                             'IEEE 754 round-trip float correctness',
                             'Rich parse errors: line/column/offset + caret rendering (format_error)',
-                            '591 passing tests, 12 libFuzzer targets',
+                            '596 passing tests, 12 libFuzzer targets',
                             'STL container support (vector, map, optional, tuple, variant)',
                             'Enum support: integer by default, value-name via QBUEM_JSON_ENUM (JSON + CBOR)',
+                            'Field rename (member, "jsonKey") and skip-by-omission, across JSON/fuse/CBOR',
                             'Generic/template types via QBUEM_JSON_FIELDS_TPL (one registration, all instantiations)',
                             'Up to 2.9 GB/s parsing, 7.2 GB/s serialization',
                             'Apache 2.0 license — free for commercial use',
@@ -234,7 +235,7 @@ export default withMermaid(
                         },
                         runtimePlatform: 'C++20',
                         targetProduct: { '@id': 'https://qbuem.com/qbuem-json/#application' },
-                        version: '1.4.0',
+                        version: '1.5.0',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
                         keywords: 'C++, JSON, SIMD, AVX-512, High-Performance, HFT, parser, serializer, zero-allocation',
                         author: { '@id': 'https://qbuem.com/#organization' }
@@ -390,9 +391,9 @@ export default withMermaid(
                     ]
                 },
                 {
-                    text: 'v1.4.0',
+                    text: 'v1.5.0',
                     items: [
-                        { text: 'Release Notes', link: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.4.0' },
+                        { text: 'Release Notes', link: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.5.0' },
                         { text: 'All Releases', link: 'https://github.com/qbuem/qbuem-json/releases' }
                     ]
                 }

--- a/docs/guide/mapping.md
+++ b/docs/guide/mapping.md
@@ -141,6 +141,40 @@ It emits the same ADL surface as `QBUEM_JSON_FIELDS` (DOM `read`/`write`, Nexus 
 - The parentheses around the two type arguments are required; they are what lets multi-parameter templates (`(Pair<A, B>)`) pass through the preprocessor. A bare `QBUEM_JSON_FIELDS(Pair<int, std::string>, …)` does **not** compile because the preprocessor splits on the comma inside `<…>` — wrap multi-param instantiations in a `using` alias, or use `QBUEM_JSON_FIELDS_TPL`.
 :::
 
+### Renaming & skipping fields {#rename-skip}
+
+By default a field's JSON/CBOR key is its C++ member name. To use a **different
+wire key**, write the field as `(member, "jsonKey")` — useful for snake_case C++
+↔ camelCase JSON, reserved words, or matching a third-party API:
+
+```cpp
+struct User {
+    int64_t     id;
+    std::string user_name;   // C++ snake_case
+    int         level;
+};
+QBUEM_JSON_FIELDS(User, (id, "userId"), (user_name, "userName"), level)
+
+qbuem::write(User{7, "neo", 42});
+// {"userId":7,"userName":"neo","level":42}
+```
+
+A bare field name behaves exactly as before, so renaming is opt-in per field and
+mixes freely with bare fields. Rename works across **DOM, `fuse`, and CBOR**, and
+composes with [`QBUEM_JSON_FIELDS_TPL`](#generic-template-types).
+
+**Skipping a field needs no syntax** — simply omit it from the list. A member
+that isn't registered is neither serialized nor read (and is left at its default
+on read). So computed/internal members just stay off the macro:
+
+```cpp
+struct Account {
+    std::string name;
+    std::string password_hash;  // not listed → never serialized or read
+};
+QBUEM_JSON_FIELDS(Account, name)
+```
+
 ### Enums {#enums}
 
 Any `enum` / `enum class` works out of the box, serializing as its **underlying

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -265,6 +265,14 @@ QBUEM_JSON_FIELDS(User, id)  // ✅
 
 Supports up to 32 fields. For more, use manual ADL hooks (`nexus_pulse`, `from_qbuem_json`, `to_qbuem_json`).
 
+Rename a field's wire key by writing it as `(member, "jsonKey")`; a bare name uses the member name. Skip a field by omitting it from the list (it is neither serialized nor read). Both work across DOM/fuse/CBOR.
+
+```cpp
+struct User { int64_t id; std::string user_name; int level; std::string secret; };
+QBUEM_JSON_FIELDS(User, (id, "userId"), (user_name, "userName"), level)  // secret omitted → skipped
+// {"userId":7,"userName":"neo","level":42}
+```
+
 Generic (template) types: register a class template once for ALL instantiations with `QBUEM_JSON_FIELDS_TPL`. Wrap the template-parameter list and the dependent type in parentheses, then list fields. Emits the same ADL surface (DOM read/write, fuse, FastWriter, CBOR) as function templates.
 
 ```cpp

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -22,7 +22,7 @@ Minimum requirements: C++20, GCC 13+ or Clang 18+ or Apple Clang. Supported plat
 - [Custom Allocators](https://qbuem.com/qbuem-json/guide/allocators): Arena allocators, stack allocators, custom memory strategies
 - [Language Bindings](https://qbuem.com/qbuem-json/guide/bindings): C FFI, Python, Rust, Go bindings
 - [Low-Latency Patterns](https://qbuem.com/qbuem-json/guide/low-latency-patterns): HFT tick data patterns, pre-allocated documents, reuse strategies
-- [Correctness & Safety](https://qbuem.com/qbuem-json/guide/correctness): RFC 8259/6901/6902/8949 compliance, IEEE 754 round-trip, rich parse errors (line/column/caret), enum support, 591 tests, sanitizers, fuzzing
+- [Correctness & Safety](https://qbuem.com/qbuem-json/guide/correctness): RFC 8259/6901/6902/8949 compliance, IEEE 754 round-trip, rich parse errors (line/column/caret), enum support, field rename/skip, 596 tests, sanitizers, fuzzing
 - [Benchmarks](https://qbuem.com/qbuem-json/guide/benchmarks): Live CI benchmark results vs. simdjson, yyjson, RapidJSON, nlohmann
 - [Vision & Roadmap](https://qbuem.com/qbuem-json/guide/vision): Project goals and planned features
 

--- a/include/qbuem_json/qbuem_json.hpp
+++ b/include/qbuem_json/qbuem_json.hpp
@@ -1,6 +1,13 @@
 /**
- * @brief qbuem-json v1.4.0 - High-Performance C++20 JSON Parser
- * @version 1.4.0
+ * @brief qbuem-json v1.5.0 - High-Performance C++20 JSON Parser
+ * @version 1.5.0
+ *
+ * v1.5.0: Field rename (roadmap Tier 1). A field in QBUEM_JSON_FIELDS may now be
+ *         written `(member, "jsonKey")` to map it to a different wire key
+ *         (snake_case C++ ↔ camelCase JSON, reserved words, API interop); a bare
+ *         name behaves exactly as before. Skipping a field needs no syntax —
+ *         omit it from the list. Works across DOM, fuse, and CBOR, and composes
+ *         with QBUEM_JSON_FIELDS_TPL.
  *
  * v1.4.0: Enum support (roadmap Tier 1). Any enum/enum class now serializes out
  *         of the box as its underlying integer across every engine (DOM, fuse,
@@ -9364,21 +9371,57 @@ inline void to_json_field(Value &obj, const char *key, const T &val) {
   QBUEM_DETAIL_EXPAND(QBUEM_DETAIL_CONCAT2(                                    \
       QBUEM_DETAIL_FE_, QBUEM_DETAIL_COUNT(__VA_ARGS__))(fn, __VA_ARGS__))
 
+// ── Field spec normalization (rename) ────────────────────────────────────────
+// A field listed in QBUEM_JSON_FIELDS may be either a bare member name, which
+// uses its own identifier as the JSON/CBOR key, or `(member, "jsonKey")` to map
+// it to a different wire key (rename — e.g. snake_case C++ ↔ camelCase JSON, or a
+// reserved word).  The two helpers below extract the C++ member token and the
+// key string-literal from either form.  Skipping a field needs no syntax: omit
+// it from the list and it is neither serialized nor read.
+//
+//   QBUEM_FIELD_CPP(score)            → score        QBUEM_FIELD_KEY(score)            → "score"
+//   QBUEM_FIELD_CPP((score, "pts"))   → score        QBUEM_FIELD_KEY((score, "pts"))   → "pts"
+#define QBUEM_DETAIL_FIELD_FST(a, ...) a
+#define QBUEM_DETAIL_FIELD_SND(a, b) b
+// QBUEM_DETAIL_IS_PAREN(x): 1 if x is parenthesized, else 0.
+#define QBUEM_DETAIL_CHECK_N(x, n, ...) n
+#define QBUEM_DETAIL_CHECK(...) QBUEM_DETAIL_EXPAND(QBUEM_DETAIL_CHECK_N(__VA_ARGS__, 0,))
+#define QBUEM_DETAIL_PROBE_PAREN(...) ~, 1,
+#define QBUEM_DETAIL_IS_PAREN(x) QBUEM_DETAIL_CHECK(QBUEM_DETAIL_PROBE_PAREN x)
+#define QBUEM_DETAIL_IIF(cond) QBUEM_DETAIL_CONCAT2(QBUEM_DETAIL_IIF_, cond)
+#define QBUEM_DETAIL_IIF_0(t, f) f
+#define QBUEM_DETAIL_IIF_1(t, f) t
+
+#define QBUEM_FIELD_CPP(F)                                                     \
+  QBUEM_DETAIL_IIF(QBUEM_DETAIL_IS_PAREN(F))                                   \
+  (QBUEM_FIELD_CPP_P, QBUEM_FIELD_CPP_B)(F)
+#define QBUEM_FIELD_CPP_B(n) n
+#define QBUEM_FIELD_CPP_P(t) QBUEM_DETAIL_FIELD_FST t
+
+#define QBUEM_FIELD_KEY(F)                                                     \
+  QBUEM_DETAIL_IIF(QBUEM_DETAIL_IS_PAREN(F))                                   \
+  (QBUEM_FIELD_KEY_P, QBUEM_FIELD_KEY_B)(F)
+#define QBUEM_FIELD_KEY_B(n) #n
+#define QBUEM_FIELD_KEY_P(t) QBUEM_DETAIL_FIELD_SND t
+
 // ============================================================================
 // QBUEM_JSON_FIELDS — one-line struct serialization/deserialization
 // ============================================================================
 
 #define QBUEM_JSON_DETAIL_READ(f)                                              \
-  ::qbuem::json::detail::from_json_field(v, #f, obj.f);
+  ::qbuem::json::detail::from_json_field(v, QBUEM_FIELD_KEY(f),                \
+                                         obj.QBUEM_FIELD_CPP(f));
 #define QBUEM_JSON_DETAIL_WRITE(f)                                             \
-  ::qbuem::json::detail::to_json_field(v, #f, obj.f);
+  ::qbuem::json::detail::to_json_field(v, QBUEM_FIELD_KEY(f),                  \
+                                       obj.QBUEM_FIELD_CPP(f));
 #define QBUEM_JSON_DETAIL_PULSE(f)                                             \
-  case ::qbuem::json::detail::fast_key_hash_ce(#f):                            \
+  case ::qbuem::json::detail::fast_key_hash_ce(QBUEM_FIELD_KEY(f)):            \
     /* Verify the actual key bytes — the hash is collision-prone, so without  \
        this an untrusted key could be routed into the wrong field (spoofing / \
        type confusion).  One short compare per object key. */                 \
-    if (_key == ::std::string_view(#f, sizeof(#f) - 1))                        \
-      ::qbuem::json::detail::from_json_direct(p, end, obj.f);                  \
+    if (_key == ::std::string_view(QBUEM_FIELD_KEY(f),                        \
+                                   sizeof(QBUEM_FIELD_KEY(f)) - 1))            \
+      ::qbuem::json::detail::from_json_direct(p, end, obj.QBUEM_FIELD_CPP(f)); \
     else                                                                       \
       ::qbuem::json::detail::skip_direct(p, end);                              \
     break;
@@ -9386,28 +9429,29 @@ inline void to_json_field(Value &obj, const char *key, const T &val) {
 // QBUEM_JSON_DETAIL_APPEND_FW — FastWriter path: zero std::string overhead
 #define QBUEM_JSON_DETAIL_APPEND_FW(f)                                         \
   {                                                                            \
-    static constexpr char _bj_kf[] = "\"" #f "\":";                           \
+    static constexpr char _bj_kf[] = "\"" QBUEM_FIELD_KEY(f) "\":";           \
     _bj_fw.write(_bj_kf, sizeof(_bj_kf) - 1);                                 \
   }                                                                            \
-  ::qbuem::json::detail::append_json(_bj_fw, obj.f);                          \
+  ::qbuem::json::detail::append_json(_bj_fw, obj.QBUEM_FIELD_CPP(f));         \
   _bj_fw.put(',');
 
 // QBUEM_JSON_DETAIL_APPEND_CBOR — one CBOR map entry: text key + value
 #define QBUEM_JSON_DETAIL_APPEND_CBOR(f)                                       \
   {                                                                            \
-    static constexpr auto _bck = ::qbuem::json::detail::make_cbor_key(#f);     \
+    static constexpr auto _bck =                                              \
+        ::qbuem::json::detail::make_cbor_key(QBUEM_FIELD_KEY(f));              \
     ::qbuem::json::detail::json_write(_bj_w, _bck.data(), _bck.size());        \
   }                                                                            \
-  ::qbuem::json::detail::append_cbor(_bj_w, obj.f);
+  ::qbuem::json::detail::append_cbor(_bj_w, obj.QBUEM_FIELD_CPP(f));
 
 // QBUEM_JSON_DETAIL_CBOR_READ — one switch case routing a CBOR map key to its
 // field.  The hash is collision-prone, so the key bytes are verified before the
 // field is filled (same spoofing defence as the JSON nexus_pulse path); an
 // unmatched key has its value skipped wholesale.
 #define QBUEM_JSON_DETAIL_CBOR_READ(f)                                         \
-  case ::qbuem::json::detail::fast_key_hash_ce(#f):                            \
-    if (::qbuem::json::detail::cbor_key_matches(_key, #f))                     \
-      ::qbuem::json::detail::from_cbor(_cr, obj.f);                            \
+  case ::qbuem::json::detail::fast_key_hash_ce(QBUEM_FIELD_KEY(f)):            \
+    if (::qbuem::json::detail::cbor_key_matches(_key, QBUEM_FIELD_KEY(f)))     \
+      ::qbuem::json::detail::from_cbor(_cr, obj.QBUEM_FIELD_CPP(f));           \
     else                                                                       \
       ::qbuem::json::detail::cbor_skip(_cr);                                   \
     break;
@@ -9422,9 +9466,9 @@ inline void to_json_field(Value &obj, const char *key, const T &val) {
 // correct, just without the fast path.
 #define QBUEM_JSON_DETAIL_CBOR_FAST(f)                                         \
   if (_bfast && (_bindef ? !_cr.peek_break() : (_bi < _bn)) &&                 \
-      _cr.peek_key_eq(#f)) {                                                   \
-    _cr.skip_short_key(sizeof(#f) - 1);                                        \
-    ::qbuem::json::detail::from_cbor(_cr, obj.f);                              \
+      _cr.peek_key_eq(QBUEM_FIELD_KEY(f))) {                                   \
+    _cr.skip_short_key(sizeof(QBUEM_FIELD_KEY(f)) - 1);                        \
+    ::qbuem::json::detail::from_cbor(_cr, obj.QBUEM_FIELD_CPP(f));             \
     ++_bi;                                                                     \
   } else {                                                                     \
     _bfast = false;                                                           \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ add_qbuem_gtest(test_serializer)
 add_qbuem_gtest(test_errors)
 add_qbuem_gtest(test_cbor)
 add_qbuem_gtest(test_enum)
+add_qbuem_gtest(test_field_rename)
 
 # ── New: dom API type coverage and round-trip fidelity ────────────────────
 add_qbuem_gtest(test_dom_types)

--- a/tests/test_field_rename.cpp
+++ b/tests/test_field_rename.cpp
@@ -1,0 +1,79 @@
+// Field rename (roadmap Tier 1): a field may be written `(member, "jsonKey")` to
+// map it to a different wire key. Skipping is by omission — a member not listed
+// in QBUEM_JSON_FIELDS is neither serialized nor read. Verified across every
+// engine (DOM read/write, fuse, CBOR).
+#include <gtest/gtest.h>
+
+#include "qbuem_json/qbuem_json.hpp"
+
+#include <cstdint>
+#include <string>
+
+struct User {
+  int64_t     id;
+  std::string user_name;   // → "userName"
+  int         level;       // bare key
+  int         internal;    // NOT registered → skipped
+};
+QBUEM_JSON_FIELDS(User, (id, "userId"), (user_name, "userName"), level)
+
+// A renamed field nested inside another struct, plus a renamed long key (>8 B,
+// exercises the full-compare path in the CBOR/JSON verify).
+struct Outer {
+  User                 owner;
+  std::string          description_text;  // → "description"
+};
+QBUEM_JSON_FIELDS(Outer, (owner, "user"), (description_text, "description"))
+
+TEST(FieldRename, JsonUsesRenamedKeys) {
+  const std::string j = qbuem::write(User{7, "neo", 42, 999});
+  EXPECT_NE(j.find("\"userId\":7"), std::string::npos);
+  EXPECT_NE(j.find("\"userName\":\"neo\""), std::string::npos);
+  EXPECT_NE(j.find("\"level\":42"), std::string::npos);
+  EXPECT_EQ(j.find("internal"), std::string::npos); // skipped by omission
+  EXPECT_EQ(j.find("user_name"), std::string::npos); // C++ name not leaked
+}
+
+TEST(FieldRename, DomReadRenamedKeys) {
+  auto a = qbuem::read<User>(
+      R"({"userId":11,"userName":"trinity","level":5,"internal":123})");
+  EXPECT_EQ(a.id, 11);
+  EXPECT_EQ(a.user_name, "trinity");
+  EXPECT_EQ(a.level, 5);
+  EXPECT_EQ(a.internal, 0); // skipped → left at default, not 123
+}
+
+TEST(FieldRename, FuseReadRenamedKeys) {
+  auto f = qbuem::fuse<User>(
+      R"({"userId":3,"userName":"morpheus","level":9})");
+  EXPECT_EQ(f.id, 3);
+  EXPECT_EQ(f.user_name, "morpheus");
+  EXPECT_EQ(f.level, 9);
+}
+
+TEST(FieldRename, CborRoundTripRenamedKeys) {
+  User u{7, "neo", 42, 999};
+  auto c = qbuem::cbor::decode<User>(qbuem::cbor::encode(u));
+  EXPECT_EQ(c.id, 7);
+  EXPECT_EQ(c.user_name, "neo");
+  EXPECT_EQ(c.level, 42);
+  // The CBOR map must carry the renamed text key, not the C++ member name.
+  std::string bytes = qbuem::cbor::encode(u);
+  EXPECT_NE(bytes.find("userName"), std::string::npos);
+  EXPECT_EQ(bytes.find("user_name"), std::string::npos);
+}
+
+TEST(FieldRename, NestedAndLongRenamedKeys) {
+  Outer o{ User{1, "a", 2, 0}, "hello world" };
+  const std::string j = qbuem::write(o);
+  EXPECT_NE(j.find("\"user\":"), std::string::npos);
+  EXPECT_NE(j.find("\"description\":\"hello world\""), std::string::npos);
+
+  auto dom = qbuem::read<Outer>(j);
+  EXPECT_EQ(dom.owner.user_name, "a");
+  EXPECT_EQ(dom.description_text, "hello world");
+
+  auto cb = qbuem::cbor::decode<Outer>(qbuem::cbor::encode(o));
+  EXPECT_EQ(cb.owner.id, 1);
+  EXPECT_EQ(cb.description_text, "hello world");
+}


### PR DESCRIPTION
**Roadmap Tier 1 #2** (serde-style attributes) — completes the set after enum + default.

## Behavior
- **Rename:** write a field as `(member, "jsonKey")` to map it to a different wire key (snake_case C++ ↔ camelCase JSON, reserved words, third-party API interop). A bare name behaves exactly as before — rename is opt-in per field and mixes with bare fields.

```cpp
QBUEM_JSON_FIELDS(User, (id, "userId"), (user_name, "userName"), level)
// {"userId":7,"userName":"neo","level":42}
```

- **Skip:** needs no syntax — omit the member and it is neither serialized nor read (left at its default on read). Secret/computed members just stay off the macro.

## Implementation
Two preprocessor normalizers — `QBUEM_FIELD_CPP(f)` (member token) and `QBUEM_FIELD_KEY(f)` (key string-literal) — select on whether the field arg is parenthesized (standard `IS_PAREN` probe). The 7 per-field detail macros route through them instead of bare `#f` / `obj.f`.

For a **bare field the normalizers produce byte-identical tokens**, so the change is behavior-preserving for every existing registration — proven by the full suite still passing unchanged. Shared detail macros → rename also composes with `QBUEM_JSON_FIELDS_TPL`.

## Verification
- `tests/test_field_rename.cpp` (5): JSON renamed keys + skip-by-omission + no C++-name leak, DOM read, fuse read, CBOR round-trip (renamed text key on the wire), nested + long (>8 B) renamed keys (full-compare verify path).
- **596/596** pass (Release + ASan/UBSan); CBOR fuzz **8M iters clean**.
- Docs: `guide/mapping.md` "Renaming & skipping", `llms.txt`/`llms-full.txt`, SEO; version **1.4.0 → 1.5.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)