### PR TITLE
feat: canonical JSON — qbuem::canonicalize (v1.7.0, completes Tier 1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(qbuem_json VERSION 1.6.0 LANGUAGES CXX)
+project(qbuem_json VERSION 1.7.0 LANGUAGES CXX)
 
 # Library Target
 add_library(qbuem_json INTERFACE)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -179,10 +179,10 @@ export default withMermaid(
                         applicationCategory: 'DeveloperApplication',
                         applicationSubCategory: 'C++ Library',
                         operatingSystem: 'Linux, macOS',
-                        version: '1.6.0',
-                        softwareVersion: '1.6.0',
-                        releaseNotes: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.6.0',
-                        downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.6.0',
+                        version: '1.7.0',
+                        softwareVersion: '1.7.0',
+                        releaseNotes: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.7.0',
+                        downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.7.0',
                         installUrl: 'https://qbuem.com/qbuem-json/guide/getting-started',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
                         keywords: 'C++ JSON library, C++20 JSON, fastest JSON parser, SIMD JSON, AVX-512 JSON, zero-allocation JSON, high-performance JSON, HFT JSON, JSON serializer, single header JSON, header-only JSON, CBOR C++, RFC 8949 CBOR, binary serialization C++, nlohmann alternative, simdjson alternative, RapidJSON alternative',
@@ -196,11 +196,12 @@ export default withMermaid(
                             'RFC 8259, RFC 6901, RFC 6902, RFC 8949 compliant',
                             'IEEE 754 round-trip float correctness',
                             'Rich parse errors: line/column/offset + caret rendering (format_error)',
-                            '603 passing tests, 13 libFuzzer targets',
+                            '613 passing tests, 13 libFuzzer targets',
                             'STL container support (vector, map, optional, tuple, variant)',
                             'Enum support: integer by default, value-name via QBUEM_JSON_ENUM (JSON + CBOR)',
                             'Field rename (member, "jsonKey") and skip-by-omission, across JSON/fuse/CBOR',
                             'NDJSON / JSON Lines streaming (read_lines / write_lines) in bounded memory',
+                            'Canonical JSON (qbuem::canonicalize) — deterministic bytes for hashing/signing (RFC 8785-style)',
                             'Generic/template types via QBUEM_JSON_FIELDS_TPL (one registration, all instantiations)',
                             'Up to 2.9 GB/s parsing, 7.2 GB/s serialization',
                             'Apache 2.0 license — free for commercial use',
@@ -236,7 +237,7 @@ export default withMermaid(
                         },
                         runtimePlatform: 'C++20',
                         targetProduct: { '@id': 'https://qbuem.com/qbuem-json/#application' },
-                        version: '1.6.0',
+                        version: '1.7.0',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
                         keywords: 'C++, JSON, SIMD, AVX-512, High-Performance, HFT, parser, serializer, zero-allocation',
                         author: { '@id': 'https://qbuem.com/#organization' }
@@ -392,9 +393,9 @@ export default withMermaid(
                     ]
                 },
                 {
-                    text: 'v1.6.0',
+                    text: 'v1.7.0',
                     items: [
-                        { text: 'Release Notes', link: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.6.0' },
+                        { text: 'Release Notes', link: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.7.0' },
                         { text: 'All Releases', link: 'https://github.com/qbuem/qbuem-json/releases' }
                     ]
                 }

--- a/docs/guide/serialization.md
+++ b/docs/guide/serialization.md
@@ -107,6 +107,40 @@ to that record.
 
 ---
 
+## 🔒 Canonical JSON (deterministic output)
+
+`qbuem::canonicalize` produces a **deterministic** serialization — the same
+logical document always yields the same bytes — so it can be hashed, signed, or
+content-addressed:
+
+```cpp
+qbuem::canonicalize(R"({ "b":1, "a":2, "c":[3, 2] })");
+// {"a":2,"b":1,"c":[3,2]}
+
+qbuem::canonicalize(R"({"x":1.50,"y":1e2,"z":-0.0})");
+// {"x":1.5,"y":100,"z":0}
+```
+
+It follows the [RFC 8785 (JCS)](https://www.rfc-editor.org/rfc/rfc8785.html)
+structure: object keys sorted, no insignificant whitespace, shortest numeric
+forms, minimal string escaping, and `-0` normalized to `0`. Input is
+**strict-parsed** (a canonical form is only meaningful for valid input), so
+malformed JSON throws `qbuem::parse_error`.
+
+> [!NOTE] Scope vs byte-exact RFC 8785
+> Two intentional simplifications: keys are ordered by Unicode code point (UTF-8
+> byte order) rather than UTF-16 — identical except for keys with
+> supplementary-plane characters — and numbers use the library's shortest
+> round-trip form, which matches RFC 8785 across the common range but may differ
+> in exponential notation for extreme magnitudes (`1E21` vs `1e+21`). For
+> in-toolchain hashing/dedup this is fully deterministic.
+>
+> **CBOR is canonical by construction:** a `QBUEM_JSON_FIELDS` struct always emits
+> a definite-length map with fields in declaration order and shortest integers —
+> so `cbor::encode` of a given struct is already byte-stable across runs.
+
+---
+
 ## 🚀 Quick Start
 
 ```cpp

--- a/docs/guide/vision.md
+++ b/docs/guide/vision.md
@@ -25,7 +25,7 @@ The full, sourced roadmap lives in [`ROADMAP.md`](https://github.com/qbuem/qbuem
 - ✅ **Rich error context** — `parse_error` exposes line/column + `format_error()` caret rendering *(v1.3.0)*.
 - ✅ **serde-style field attributes** — enum (integer default + `QBUEM_JSON_ENUM` value names) *(v1.4.0)*, field rename `(member, "jsonKey")` + skip-by-omission *(v1.5.0)*, default-on-absent (built in).
 - ✅ **NDJSON / JSON Lines** streaming — `read_lines` / `write_lines`, bounded memory *(v1.6.0)*.
-- ⬜ **Deterministic / canonical CBOR** + **JSON Canonicalization (RFC 8785 / JCS)** — reproducible bytes for signing & hashing.
+- ✅ **Canonical JSON** — `qbuem::canonicalize`, deterministic bytes for hashing/signing (RFC 8785-style); CBOR is canonical by construction *(v1.7.0)*.
 
 ## Tier 2 — Mid-term (v1.4–1.5)
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -443,6 +443,12 @@ std::vector<LogEntry> all = qbuem::read_lines<LogEntry>(text);     // collect
 std::string out = qbuem::write_lines(all);                          // serialize a range
 ```
 
+Canonical JSON: qbuem::canonicalize(json) returns a deterministic serialization (sorted keys, no whitespace, shortest numbers, minimal escaping, -0 normalized) for hashing/signing/content-addressing — RFC 8785 (JCS) structure; strict-parses input. CBOR is canonical by construction (definite map, declaration-order fields, shortest ints).
+
+```cpp
+qbuem::canonicalize(R"({ "b":1, "a":2 })");  // {"a":2,"b":1}
+```
+
 Parse failures throw qbuem::parse_error (derives from std::runtime_error). It carries offset() (0-based byte), and line()/column() (1-based); what() reads "<reason> at line L column C (byte offset N)". For binary/CBOR errors line()/column() are 0. qbuem::format_error(e, source) renders the failing line with a caret under the column (pass the same buffer you parsed):
 
 ```cpp

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -22,7 +22,7 @@ Minimum requirements: C++20, GCC 13+ or Clang 18+ or Apple Clang. Supported plat
 - [Custom Allocators](https://qbuem.com/qbuem-json/guide/allocators): Arena allocators, stack allocators, custom memory strategies
 - [Language Bindings](https://qbuem.com/qbuem-json/guide/bindings): C FFI, Python, Rust, Go bindings
 - [Low-Latency Patterns](https://qbuem.com/qbuem-json/guide/low-latency-patterns): HFT tick data patterns, pre-allocated documents, reuse strategies
-- [Correctness & Safety](https://qbuem.com/qbuem-json/guide/correctness): RFC 8259/6901/6902/8949 compliance, IEEE 754 round-trip, rich parse errors (line/column/caret), enum support, field rename/skip, NDJSON streaming, 603 tests, sanitizers, fuzzing
+- [Correctness & Safety](https://qbuem.com/qbuem-json/guide/correctness): RFC 8259/6901/6902/8949 compliance, IEEE 754 round-trip, rich parse errors (line/column/caret), enum support, field rename/skip, NDJSON streaming, canonical JSON, 613 tests, sanitizers, fuzzing
 - [Benchmarks](https://qbuem.com/qbuem-json/guide/benchmarks): Live CI benchmark results vs. simdjson, yyjson, RapidJSON, nlohmann
 - [Vision & Roadmap](https://qbuem.com/qbuem-json/guide/vision): Project goals and planned features
 

--- a/include/qbuem_json/qbuem_json.hpp
+++ b/include/qbuem_json/qbuem_json.hpp
@@ -1,6 +1,13 @@
 /**
- * @brief qbuem-json v1.6.0 - High-Performance C++20 JSON Parser
- * @version 1.6.0
+ * @brief qbuem-json v1.7.0 - High-Performance C++20 JSON Parser
+ * @version 1.7.0
+ *
+ * v1.7.0: Canonical JSON (roadmap Tier 1, final). qbuem::canonicalize(json)
+ *         returns a deterministic serialization — object keys sorted, no
+ *         whitespace, shortest numbers, minimal string escaping, -0 normalized —
+ *         so the same logical document always hashes to the same bytes (for
+ *         signing / dedup / content-addressing). Follows the RFC 8785 (JCS)
+ *         structure; strict-parses its input.
  *
  * v1.6.0: NDJSON / JSON Lines (roadmap Tier 1). qbuem::read_lines<T>(text, fn)
  *         decodes one JSON value per line, reusing a single Document so a
@@ -10424,6 +10431,75 @@ template <typename T> void from_json(const Value &v, T &out) {
 
 template <typename T>::std::string to_json_str(const T &val) {
   return ::qbuem::json::detail::to_json_str(val);
+}
+
+// ── Canonical JSON ───────────────────────────────────────────────────────────
+// qbuem::canonicalize(json) → a deterministic serialization: the SAME logical
+// document always produces the SAME bytes, so it can be hashed, signed, or
+// content-addressed.  Follows the RFC 8785 (JCS) structure: object keys sorted
+// lexicographically, no insignificant whitespace, shortest numeric forms,
+// minimal string escaping, -0 normalized to 0.
+//
+// Scope (honest about the two places it diverges from byte-exact RFC 8785):
+//   • keys are ordered by Unicode code point (UTF-8 byte order); RFC 8785 uses
+//     UTF-16 order, which differs only for keys containing supplementary-plane
+//     (non-BMP) characters.
+//   • numbers use the library's shortest round-trip format, which matches the
+//     RFC 8785 ECMAScript form across the common range; very large/small
+//     magnitudes may differ in exponential notation (e.g. "1E21" vs "1e+21").
+// For in-toolchain hashing/dedup this is fully deterministic; for cross-impl
+// RFC 8785 signing, account for the two notes above.
+
+inline void canon_emit_(const json::Value &v, ::std::string &out) {
+  if (v.is_object()) {
+    ::std::vector<::std::pair<::std::string, json::Value>> items;
+    for (const auto &[k, val] : v.items())
+      items.emplace_back(::qbuem::json::detail::json_unescape(k), val);
+    ::std::sort(items.begin(), items.end(),
+                [](const auto &a, const auto &b) { return a.first < b.first; });
+    out += '{';
+    for (::std::size_t i = 0; i < items.size(); ++i) {
+      if (i) out += ',';
+      out += to_json_str(items[i].first); // canonical (minimal) key escaping
+      out += ':';
+      canon_emit_(items[i].second, out);
+    }
+    out += '}';
+  } else if (v.is_array()) {
+    out += '[';
+    bool first = true;
+    for (const auto &e : v.elements()) {
+      if (!first) out += ',';
+      first = false;
+      canon_emit_(e, out);
+    }
+    out += ']';
+  } else if (v.is_string()) {
+    out += to_json_str(v.decoded()); // decode then re-escape minimally
+  } else if (v.is_bool()) {
+    out += v.as<bool>() ? "true" : "false";
+  } else if (v.is_int()) {
+    out += to_json_str(v.as<int64_t>());
+  } else if (v.is_double()) {
+    double d = v.as<double>();
+    if (d == 0.0) d = 0.0; // normalize -0.0 → 0.0
+    out += to_json_str(d);
+  } else {
+    out += "null";
+  }
+}
+
+// Parse `json` and return its canonical form. Uses STRICT parsing (RFC 8259 +
+// well-formed UTF-8) — a canonical form is only meaningful for valid input, and
+// the signing/hashing use case must reject malformed data rather than silently
+// canonicalize a best-effort interpretation. Throws qbuem::parse_error otherwise.
+[[nodiscard]] inline ::std::string canonicalize(::std::string_view json) {
+  Document doc;
+  Value root = parse_strict(doc, json);
+  ::std::string out;
+  out.reserve(json.size());
+  canon_emit_(root, out);
+  return out;
 }
 
 // ── NDJSON / JSON Lines ──────────────────────────────────────────────────────

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,6 +74,7 @@ add_qbuem_gtest(test_cbor)
 add_qbuem_gtest(test_enum)
 add_qbuem_gtest(test_field_rename)
 add_qbuem_gtest(test_ndjson)
+add_qbuem_gtest(test_canonical)
 
 # ── New: dom API type coverage and round-trip fidelity ────────────────────
 add_qbuem_gtest(test_dom_types)

--- a/tests/test_canonical.cpp
+++ b/tests/test_canonical.cpp
@@ -1,0 +1,52 @@
+// Canonical JSON (roadmap Tier 1): qbuem::canonicalize produces a deterministic
+// serialization — sorted keys, no whitespace, shortest numbers, minimal escaping,
+// -0 normalized — so the same logical document hashes to the same bytes.
+#include <gtest/gtest.h>
+
+#include "qbuem_json/qbuem_json.hpp"
+
+#include <string>
+
+TEST(Canonical, SortsKeysAndStripsWhitespace) {
+  EXPECT_EQ(qbuem::canonicalize("{ \"b\":1, \"a\":2, \"c\":[3, 2] }"),
+            "{\"a\":2,\"b\":1,\"c\":[3,2]}");
+}
+
+TEST(Canonical, ShortensNumbersAndNormalizesNegativeZero) {
+  EXPECT_EQ(qbuem::canonicalize("{\"x\":1.50,\"y\":1e2,\"z\":-0.0}"),
+            "{\"x\":1.5,\"y\":100,\"z\":0}");
+}
+
+TEST(Canonical, RecursesIntoNestedObjects) {
+  EXPECT_EQ(qbuem::canonicalize("{\"o\":{\"z\":1,\"a\":{\"y\":1,\"b\":2}}}"),
+            "{\"o\":{\"a\":{\"b\":2,\"y\":1},\"z\":1}}");
+}
+
+TEST(Canonical, DecodesAndMinimallyReescapesStrings) {
+  // A → A, escaped newline stays \n.
+  EXPECT_EQ(qbuem::canonicalize("{\"k\":\"\\u0041\\nB\"}"), "{\"k\":\"A\\nB\"}");
+}
+
+TEST(Canonical, NormalizesEscapedKeysAndSortsByDecodedValue) {
+  EXPECT_EQ(qbuem::canonicalize("{\"\\u0062\":1,\"a\":2}"), "{\"a\":2,\"b\":1}");
+}
+
+TEST(Canonical, IsDeterministicAcrossKeyOrder) {
+  EXPECT_EQ(qbuem::canonicalize("{\"a\":1,\"b\":2,\"c\":3}"),
+            qbuem::canonicalize("{\"c\":3,\"a\":1,\"b\":2}"));
+}
+
+TEST(Canonical, IsIdempotent) {
+  const std::string once = qbuem::canonicalize("{\"b\":[1,2],\"a\":{\"d\":4,\"c\":3}}");
+  EXPECT_EQ(qbuem::canonicalize(once), once);
+}
+
+TEST(Canonical, ArraysPreserveOrderAndScalarsRoundTrip) {
+  EXPECT_EQ(qbuem::canonicalize("[3, 1, 2]"), "[3,1,2]");
+  EXPECT_EQ(qbuem::canonicalize("  \"hi\" "), "\"hi\"");
+  EXPECT_EQ(qbuem::canonicalize("null"), "null");
+}
+
+TEST(Canonical, InvalidInputThrows) {
+  EXPECT_THROW((void)qbuem::canonicalize("{\"a\":}"), qbuem::parse_error);
+}


### PR DESCRIPTION
**Roadmap Tier 1 #4 — the last Tier 1 item.** `qbuem::canonicalize(json)` returns a **deterministic** serialization so the same logical document always hashes to the same bytes — for signing, deduplication, content-addressing.

```cpp
qbuem::canonicalize(R"({ "b":1, "a":2, "c":[3, 2] })");  // {"a":2,"b":1,"c":[3,2]}
qbuem::canonicalize(R"({"x":1.50,"y":1e2,"z":-0.0})");    // {"x":1.5,"y":100,"z":0}
```

Follows the [RFC 8785 (JCS)](https://www.rfc-editor.org/rfc/rfc8785.html) structure: keys sorted, no whitespace, **numbers re-serialized to shortest** (`1.50`→`1.5`), minimal string escaping (decode then re-escape), `-0`→`0`. Recurses; keys + string values are decoded before re-emit so two spellings canonicalize identically. **Strict-parses** input (a canonical form is only meaningful for valid input).

### Honest scope vs byte-exact RFC 8785 (documented)
- Keys order by **Unicode code point (UTF-8 byte order)**, not UTF-16 — differs only for supplementary-plane keys.
- Numbers use **shortest round-trip**, matching across the common range; extreme magnitudes may differ in exponential notation (`1E21` vs `1e+21`).

Fully deterministic for in-toolchain hashing/dedup. Also documents that **CBOR is canonical by construction** (definite map, declaration-order fields, shortest ints).

## Verification
- `tests/test_canonical.cpp` (9): key sort + whitespace, number shorten + `-0`, recursive nesting, string decode/re-escape, escaped-key normalization, determinism across key order, idempotence, arrays/scalars, strict-parse rejects malformed.
- **613/613** pass (Release + ASan/UBSan).
- Docs: `serialization.md` "Canonical JSON", `vision.md` (**Tier 1 complete**), `llms.txt`/full, SEO; version **1.6.0 → 1.7.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)