### PR TITLE
feat: JSONPath query — qbuem::query (RFC 9535 structural selectors) (v1.8.0)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -63,7 +63,7 @@ jobs:
         status=0
         for t in fuzz_parse fuzz_dom fuzz_nexus fuzz_direct fuzz_pmr \
                  fuzz_patch fuzz_api_stress fuzz_rfc8259 fuzz_float fuzz_cbor \
-                 fuzz_ndjson; do
+                 fuzz_ndjson fuzz_jsonpath; do
           echo "::group::$t (${SECS}s)"
           if ! ./build-fuzz/fuzz/$t fuzz/corpus -dict=fuzz/json.dict \
                  -max_len=65536 -rss_limit_mb=4096 -max_total_time=$SECS \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(qbuem_json VERSION 1.7.0 LANGUAGES CXX)
+project(qbuem_json VERSION 1.8.0 LANGUAGES CXX)
 
 # Library Target
 add_library(qbuem_json INTERFACE)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -179,10 +179,10 @@ export default withMermaid(
                         applicationCategory: 'DeveloperApplication',
                         applicationSubCategory: 'C++ Library',
                         operatingSystem: 'Linux, macOS',
-                        version: '1.7.0',
-                        softwareVersion: '1.7.0',
-                        releaseNotes: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.7.0',
-                        downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.7.0',
+                        version: '1.8.0',
+                        softwareVersion: '1.8.0',
+                        releaseNotes: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.8.0',
+                        downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.8.0',
                         installUrl: 'https://qbuem.com/qbuem-json/guide/getting-started',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
                         keywords: 'C++ JSON library, C++20 JSON, fastest JSON parser, SIMD JSON, AVX-512 JSON, zero-allocation JSON, high-performance JSON, HFT JSON, JSON serializer, single header JSON, header-only JSON, CBOR C++, RFC 8949 CBOR, binary serialization C++, nlohmann alternative, simdjson alternative, RapidJSON alternative',
@@ -193,15 +193,16 @@ export default withMermaid(
                             'CBOR (RFC 8949) binary codec — same field list, cross-language (e.g. JS cbor-x)',
                             'Single header file, zero external dependencies',
                             'C++20 concepts-based API',
-                            'RFC 8259, RFC 6901, RFC 6902, RFC 8949 compliant',
+                            'RFC 8259, RFC 6901, RFC 6902, RFC 8949, RFC 9535 (JSONPath) compliant',
                             'IEEE 754 round-trip float correctness',
                             'Rich parse errors: line/column/offset + caret rendering (format_error)',
-                            '613 passing tests, 13 libFuzzer targets',
+                            '623 passing tests, 14 libFuzzer targets',
                             'STL container support (vector, map, optional, tuple, variant)',
                             'Enum support: integer by default, value-name via QBUEM_JSON_ENUM (JSON + CBOR)',
                             'Field rename (member, "jsonKey") and skip-by-omission, across JSON/fuse/CBOR',
                             'NDJSON / JSON Lines streaming (read_lines / write_lines) in bounded memory',
                             'Canonical JSON (qbuem::canonicalize) — deterministic bytes for hashing/signing (RFC 8785-style)',
+                            'JSONPath query (qbuem::query, RFC 9535 structural selectors: wildcard, recursive descent, slices)',
                             'Generic/template types via QBUEM_JSON_FIELDS_TPL (one registration, all instantiations)',
                             'Up to 2.9 GB/s parsing, 7.2 GB/s serialization',
                             'Apache 2.0 license — free for commercial use',
@@ -237,7 +238,7 @@ export default withMermaid(
                         },
                         runtimePlatform: 'C++20',
                         targetProduct: { '@id': 'https://qbuem.com/qbuem-json/#application' },
-                        version: '1.7.0',
+                        version: '1.8.0',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
                         keywords: 'C++, JSON, SIMD, AVX-512, High-Performance, HFT, parser, serializer, zero-allocation',
                         author: { '@id': 'https://qbuem.com/#organization' }
@@ -393,9 +394,9 @@ export default withMermaid(
                     ]
                 },
                 {
-                    text: 'v1.7.0',
+                    text: 'v1.8.0',
                     items: [
-                        { text: 'Release Notes', link: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.7.0' },
+                        { text: 'Release Notes', link: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.8.0' },
                         { text: 'All Releases', link: 'https://github.com/qbuem/qbuem-json/releases' }
                     ]
                 }

--- a/docs/guide/parsing.md
+++ b/docs/guide/parsing.md
@@ -334,6 +334,39 @@ using namespace qbuem::literals;
 auto title = root.at("/store/book/1/title"_jptr).as<std::string>(); // "Effective C++"
 ```
 
+JSON Pointer addresses **one** node. For multi-match queries (wildcards,
+recursive descent, slices), use JSONPath below.
+
+---
+
+## 🛣️ JSONPath (RFC 9535)
+
+`qbuem::query(root, path)` returns **all** Values a [JSONPath](https://www.rfc-editor.org/rfc/rfc9535.html)
+query selects, in document order:
+
+```cpp
+auto root = qbuem::parse(doc, store_json);
+
+qbuem::query(root, "$.store.book[0].title");   // a single title
+qbuem::query(root, "$.store.book[-1].author"); // negative index
+qbuem::query(root, "$.store.book[*].author");  // every author (wildcard)
+qbuem::query(root, "$..price");                // every price anywhere (recursive descent)
+qbuem::query(root, "$.nums[1:4]");             // array slice
+qbuem::query(root, "$.nums[::-1]");            // reversed
+qbuem::query(root, "$.nums[0, 2, 4]");         // union of indices
+qbuem::query(root, "$['store']['bicycle']");   // bracket + quoted names
+
+for (const qbuem::Value& v : qbuem::query(root, "$.store.book[*].title"))
+    std::cout << v.as<std::string_view>() << '\n';
+```
+
+Supported selectors: root `$`, member (`.name` / `['name']`), array index incl.
+negative, wildcard (`.*` / `[*]`), recursive descent (`..`), slices
+(`[start:end:step]`), and unions. A **filter** expression (`[?...]`) is not yet
+supported and throws. A syntactically malformed query throws `qbuem::parse_error`;
+a valid query that matches nothing returns an empty vector. Returned Values view
+into the same document as `root`, so keep the document alive.
+
 ---
 
 ## ⚠️ Common Pitfalls

--- a/docs/guide/vision.md
+++ b/docs/guide/vision.md
@@ -27,9 +27,9 @@ The full, sourced roadmap lives in [`ROADMAP.md`](https://github.com/qbuem/qbuem
 - ✅ **NDJSON / JSON Lines** streaming — `read_lines` / `write_lines`, bounded memory *(v1.6.0)*.
 - ✅ **Canonical JSON** — `qbuem::canonicalize`, deterministic bytes for hashing/signing (RFC 8785-style); CBOR is canonical by construction *(v1.7.0)*.
 
-## Tier 2 — Mid-term (v1.4–1.5)
+## Tier 2 — Mid-term
 
-- ⬜ **JSONPath (RFC 9535)** — standardized query with filters, normalized paths, CTS conformance.
+- 🚧 **JSONPath (RFC 9535)** — structural selectors (root, member, index, wildcard, recursive descent, slice, union) shipped *(v1.8.0)*; filter expressions planned.
 - ⬜ **MessagePack codec** — second binary target reusing the CBOR field reflection.
 - ⬜ **SAX / event / pull API** — bounded-memory huge-document handling and transcoding.
 - ⬜ **WebAssembly build + npm package** — run the parser (and CBOR) in the browser.

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -449,6 +449,14 @@ Canonical JSON: qbuem::canonicalize(json) returns a deterministic serialization 
 qbuem::canonicalize(R"({ "b":1, "a":2 })");  // {"a":2,"b":1}
 ```
 
+JSONPath (RFC 9535 structural selectors): qbuem::query(root, path) returns all matching Values in document order. Supports root $, member (.name / ['name']), array index incl. negative, wildcard (.* / [*]), recursive descent (..), slices [start:end:step], unions. Filters [?...] are not yet supported (throw). Malformed query throws parse_error.
+
+```cpp
+qbuem::query(root, "$.store.book[*].author");  // every author
+qbuem::query(root, "$..price");                // every price (recursive descent)
+qbuem::query(root, "$.nums[1:4]");             // slice
+```
+
 Parse failures throw qbuem::parse_error (derives from std::runtime_error). It carries offset() (0-based byte), and line()/column() (1-based); what() reads "<reason> at line L column C (byte offset N)". For binary/CBOR errors line()/column() are 0. qbuem::format_error(e, source) renders the failing line with a caret under the column (pass the same buffer you parsed):
 
 ```cpp

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -22,7 +22,7 @@ Minimum requirements: C++20, GCC 13+ or Clang 18+ or Apple Clang. Supported plat
 - [Custom Allocators](https://qbuem.com/qbuem-json/guide/allocators): Arena allocators, stack allocators, custom memory strategies
 - [Language Bindings](https://qbuem.com/qbuem-json/guide/bindings): C FFI, Python, Rust, Go bindings
 - [Low-Latency Patterns](https://qbuem.com/qbuem-json/guide/low-latency-patterns): HFT tick data patterns, pre-allocated documents, reuse strategies
-- [Correctness & Safety](https://qbuem.com/qbuem-json/guide/correctness): RFC 8259/6901/6902/8949 compliance, IEEE 754 round-trip, rich parse errors (line/column/caret), enum support, field rename/skip, NDJSON streaming, canonical JSON, 613 tests, sanitizers, fuzzing
+- [Correctness & Safety](https://qbuem.com/qbuem-json/guide/correctness): RFC 8259/6901/6902/8949 compliance, IEEE 754 round-trip, rich parse errors (line/column/caret), enum support, field rename/skip, NDJSON streaming, canonical JSON, JSONPath query (RFC 9535), 623 tests, sanitizers, fuzzing
 - [Benchmarks](https://qbuem.com/qbuem-json/guide/benchmarks): Live CI benchmark results vs. simdjson, yyjson, RapidJSON, nlohmann
 - [Vision & Roadmap](https://qbuem.com/qbuem-json/guide/vision): Project goals and planned features
 

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -63,3 +63,4 @@ add_fuzz_target(fuzz_pmr)        # PMR allocator stress test
 add_fuzz_target(fuzz_patch)      # JSON Pointer & Mutation stress test
 add_fuzz_target(fuzz_cbor)       # CBOR codec: decode hostile bytes + round-trip
 add_fuzz_target(fuzz_ndjson)     # NDJSON line splitter + sub-view parse safety
+add_fuzz_target(fuzz_jsonpath)   # JSONPath query parser + evaluator on untrusted input

--- a/fuzz/fuzz_jsonpath.cpp
+++ b/fuzz/fuzz_jsonpath.cpp
@@ -1,0 +1,46 @@
+// fuzz_jsonpath — JSONPath query parser + evaluator.
+// Splits the input into a query string and a JSON document (at the first NUL, or
+// uses a fixed document otherwise) so the fuzzer drives BOTH the untrusted query
+// parser and traversal over arbitrary JSON. Must never crash / read OOB / loop.
+#include <qbuem_json/qbuem_json.hpp>
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  std::string_view in(reinterpret_cast<const char *>(data), size);
+
+  // Use the bytes up to the first NUL as the query; the rest as a JSON document.
+  size_t split = in.find('\0');
+  std::string_view query = (split == std::string_view::npos) ? in : in.substr(0, split);
+  std::string_view jsondoc =
+      (split == std::string_view::npos) ? std::string_view("{\"a\":[1,2,{\"b\":3}],\"c\":{\"a\":4}}")
+                                        : in.substr(split + 1);
+
+  // 1. Query a fixed, well-formed document — exercises the path parser hard.
+  {
+    qbuem::Document d;
+    static const char *kDoc =
+        "{\"store\":{\"book\":[{\"t\":1},{\"t\":2}],\"x\":{\"y\":3}},\"n\":[0,1,2,3,4]}";
+    try {
+      qbuem::Value root = qbuem::parse(d, kDoc);
+      auto r = qbuem::query(root, query);
+      (void)r;
+    } catch (const std::exception &) {
+    }
+  }
+
+  // 2. Query an arbitrary (fuzzer-controlled) document.
+  {
+    qbuem::Document d;
+    try {
+      qbuem::Value root = qbuem::parse(d, jsondoc);
+      auto r = qbuem::query(root, query);
+      (void)r;
+    } catch (const std::exception &) {
+    }
+  }
+
+  return 0;
+}

--- a/include/qbuem_json/qbuem_json.hpp
+++ b/include/qbuem_json/qbuem_json.hpp
@@ -1,6 +1,13 @@
 /**
- * @brief qbuem-json v1.7.0 - High-Performance C++20 JSON Parser
- * @version 1.7.0
+ * @brief qbuem-json v1.8.0 - High-Performance C++20 JSON Parser
+ * @version 1.8.0
+ *
+ * v1.8.0: JSONPath query (roadmap Tier 2, RFC 9535 structural selectors).
+ *         qbuem::query(root, "$.store.book[-1].title") returns every Value a
+ *         query selects, in document order. Supports root, member access,
+ *         array index (incl. negative), wildcard, recursive descent (..),
+ *         array slices (start:end:step), and unions. Filter expressions
+ *         ([?...]) are rejected (planned). The query parser is fuzzed.
  *
  * v1.7.0: Canonical JSON (roadmap Tier 1, final). qbuem::canonicalize(json)
  *         returns a deterministic serialization — object keys sorted, no
@@ -10500,6 +10507,257 @@ inline void canon_emit_(const json::Value &v, ::std::string &out) {
   out.reserve(json.size());
   canon_emit_(root, out);
   return out;
+}
+
+// ── JSONPath (RFC 9535 — structural selectors) ───────────────────────────────
+// qbuem::query(root, "$.store.book[0].title") returns every Value the query
+// selects, in document order.  Supported selectors: root `$`, member access
+// (`.name` / `['name']` / `["name"]`), array index incl. negative (`[0]`,
+// `[-1]`), wildcard (`.*` / `[*]`), recursive descent (`..`), array slices
+// (`[start:end:step]`), and unions (`[0, 2, 'k']`).  Filter expressions
+// (`[?...]`) are not (yet) supported — a query containing one throws.
+//
+// A syntactically malformed query throws qbuem::parse_error; a valid query that
+// matches nothing returns an empty vector.  Returned Values view into the same
+// document as `root`, so that document must outlive them.
+namespace jsonpath_detail {
+
+struct JpSelector {
+  enum class Kind { Name, Wildcard, Index, Slice };
+  Kind kind;
+  ::std::string name;                  // Kind::Name
+  int64_t index = 0;                   // Kind::Index
+  int64_t s_start = 0, s_end = 0, s_step = 1; // Kind::Slice
+  bool has_start = false, has_end = false;
+};
+struct JpSegment {
+  bool descendant = false;             // leading `..`
+  ::std::vector<JpSelector> selectors; // union of ≥1
+};
+
+struct JpParser {
+  const char *p;
+  const char *begin;
+  const char *end;
+
+  [[noreturn]] void fail(const char *msg) const {
+    ::qbuem::json::throw_parse_error(
+        msg, p, ::std::string_view(begin, static_cast<size_t>(end - begin)));
+  }
+  void ws() { while (p < end && (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r')) ++p; }
+
+  // Parse a quoted name selector ('...' or "..."), with the JSON-ish escapes the
+  // RFC allows.  Returns the decoded name.
+  ::std::string parse_quoted(char q) {
+    ::std::string out;
+    ++p; // opening quote
+    while (p < end && *p != q) {
+      char c = *p++;
+      if (c == '\\') {
+        if (p >= end) fail("JSONPath: unterminated escape");
+        char e = *p++;
+        switch (e) {
+          case 'n': out += '\n'; break;
+          case 't': out += '\t'; break;
+          case 'r': out += '\r'; break;
+          case 'b': out += '\b'; break;
+          case 'f': out += '\f'; break;
+          case '/': out += '/'; break;
+          case '\\': out += '\\'; break;
+          case '\'': out += '\''; break;
+          case '"': out += '"'; break;
+          default: out += e; break; // lenient (incl. \uXXXX left as-is is out of scope)
+        }
+      } else {
+        out += c;
+      }
+    }
+    if (p >= end) fail("JSONPath: unterminated string");
+    ++p; // closing quote
+    return out;
+  }
+
+  // Parse an optionally-signed integer; returns it and whether any digit was read.
+  bool parse_int(int64_t &out) {
+    ws();
+    const char *s = p;
+    bool neg = false;
+    if (p < end && (*p == '-' || *p == '+')) { neg = (*p == '-'); ++p; }
+    int64_t v = 0; bool any = false;
+    while (p < end && *p >= '0' && *p <= '9') { v = v * 10 + (*p - '0'); ++p; any = true; }
+    if (!any) { p = s; return false; }
+    out = neg ? -v : v;
+    return true;
+  }
+
+  // Parse one selector inside `[...]` (already past `[`, positioned at selector).
+  JpSelector parse_bracket_selector() {
+    ws();
+    if (p >= end) fail("JSONPath: unexpected end of selector");
+    if (*p == '?') fail("JSONPath: filter selectors ([?...]) are not supported");
+    if (*p == '*') { ++p; return {JpSelector::Kind::Wildcard, {}, 0, 0, 0, 1, false, false}; }
+    if (*p == '\'' || *p == '"') {
+      JpSelector s; s.kind = JpSelector::Kind::Name; s.name = parse_quoted(*p); return s;
+    }
+    // index or slice: [int] [: [int] [: [int]]]
+    JpSelector s;
+    int64_t a;
+    bool has_a = parse_int(a);
+    ws();
+    if (p < end && *p == ':') {
+      s.kind = JpSelector::Kind::Slice;
+      s.has_start = has_a; if (has_a) s.s_start = a;
+      ++p; // ':'
+      int64_t b;
+      if (parse_int(b)) { s.has_end = true; s.s_end = b; }
+      ws();
+      if (p < end && *p == ':') {
+        ++p;
+        int64_t st;
+        if (parse_int(st)) s.s_step = st;
+      }
+      return s;
+    }
+    if (!has_a) fail("JSONPath: expected name, index, slice, or '*'");
+    s.kind = JpSelector::Kind::Index; s.index = a; return s;
+  }
+
+  ::std::vector<JpSegment> parse() {
+    ::std::vector<JpSegment> segs;
+    ws();
+    if (p >= end || *p != '$') fail("JSONPath: query must start with '$'");
+    ++p;
+    while (true) {
+      ws();
+      if (p >= end) break;
+      JpSegment seg;
+      if (*p == '.' && p + 1 < end && p[1] == '.') {
+        seg.descendant = true;
+        p += 2;
+        // `..` may be followed by a name, `*`, or `[selectors]`.
+        if (p < end && *p == '[') {
+          ++p;
+          parse_bracket_list(seg);
+        } else if (p < end && *p == '*') {
+          ++p; seg.selectors.push_back({JpSelector::Kind::Wildcard, {}, 0, 0, 0, 1, false, false});
+        } else {
+          JpSelector s; s.kind = JpSelector::Kind::Name; s.name = parse_member_name();
+          if (s.name.empty()) fail("JSONPath: expected member name after '..'");
+          seg.selectors.push_back(std::move(s));
+        }
+      } else if (*p == '.') {
+        ++p;
+        if (p < end && *p == '*') { ++p; seg.selectors.push_back({JpSelector::Kind::Wildcard, {}, 0, 0, 0, 1, false, false}); }
+        else {
+          JpSelector s; s.kind = JpSelector::Kind::Name; s.name = parse_member_name();
+          if (s.name.empty()) fail("JSONPath: expected member name after '.'");
+          seg.selectors.push_back(std::move(s));
+        }
+      } else if (*p == '[') {
+        ++p;
+        parse_bracket_list(seg);
+      } else {
+        fail("JSONPath: expected '.', '..', or '[' ");
+      }
+      segs.push_back(std::move(seg));
+    }
+    return segs;
+  }
+
+  // Parse a comma-separated selector list, consuming the closing `]`.
+  void parse_bracket_list(JpSegment &seg) {
+    while (true) {
+      seg.selectors.push_back(parse_bracket_selector());
+      ws();
+      if (p < end && *p == ',') { ++p; continue; }
+      if (p < end && *p == ']') { ++p; return; }
+      fail("JSONPath: expected ',' or ']' in selector list");
+    }
+  }
+
+  // Dotted member name (unquoted): a run of name chars.
+  ::std::string parse_member_name() {
+    const char *s = p;
+    while (p < end) {
+      char c = *p;
+      if (c == '.' || c == '[' || c == ']' || c == ' ' || c == '\t' ||
+          c == '\n' || c == '\r' || c == ',')
+        break;
+      ++p;
+    }
+    return ::std::string(s, static_cast<size_t>(p - s));
+  }
+};
+
+inline void jp_collect_descendants(const Value &v, ::std::vector<Value> &out) {
+  out.push_back(v);
+  if (v.is_object()) {
+    for (const auto &[k, val] : v.items()) { (void)k; jp_collect_descendants(val, out); }
+  } else if (v.is_array()) {
+    for (const auto &e : v.elements()) jp_collect_descendants(e, out);
+  }
+}
+
+inline void jp_apply_selector(const Value &v, const JpSelector &s,
+                              ::std::vector<Value> &out) {
+  using K = JpSelector::Kind;
+  if (s.kind == K::Name) {
+    if (v.is_object()) { Value m = v[std::string_view(s.name)]; if (m.is_valid()) out.push_back(m); }
+  } else if (s.kind == K::Wildcard) {
+    if (v.is_object()) { for (const auto &[k, val] : v.items()) { (void)k; out.push_back(val); } }
+    else if (v.is_array()) { for (const auto &e : v.elements()) out.push_back(e); }
+  } else if (s.kind == K::Index) {
+    if (v.is_array()) {
+      const int64_t n = static_cast<int64_t>(v.size());
+      int64_t i = s.index < 0 ? n + s.index : s.index;
+      if (i >= 0 && i < n) { Value e = v[static_cast<size_t>(i)]; if (e.is_valid()) out.push_back(e); }
+    }
+  } else { // Slice
+    if (!v.is_array()) return;
+    const int64_t n = static_cast<int64_t>(v.size());
+    const int64_t step = s.s_step;
+    if (step == 0) return; // RFC: step 0 selects nothing
+    auto norm = [n](int64_t i) { return i >= 0 ? i : n + i; };
+    if (step > 0) {
+      int64_t lo = s.has_start ? norm(s.s_start) : 0;
+      int64_t hi = s.has_end ? norm(s.s_end) : n;
+      lo = lo < 0 ? 0 : (lo > n ? n : lo);
+      hi = hi < 0 ? 0 : (hi > n ? n : hi);
+      for (int64_t i = lo; i < hi; i += step) { Value e = v[static_cast<size_t>(i)]; if (e.is_valid()) out.push_back(e); }
+    } else {
+      int64_t up = s.has_start ? norm(s.s_start) : n - 1;
+      int64_t lo = s.has_end ? norm(s.s_end) : -n - 1;
+      up = up < -1 ? -1 : (up > n - 1 ? n - 1 : up);
+      lo = lo < -1 ? -1 : (lo > n - 1 ? n - 1 : lo);
+      for (int64_t i = up; i > lo; i += step) { Value e = v[static_cast<size_t>(i)]; if (e.is_valid()) out.push_back(e); }
+    }
+  }
+}
+
+} // namespace jsonpath_detail
+
+[[nodiscard]] inline ::std::vector<Value> query(const Value &root,
+                                                ::std::string_view path) {
+  using namespace jsonpath_detail;
+  JpParser parser{path.data(), path.data(), path.data() + path.size()};
+  const ::std::vector<JpSegment> segs = parser.parse();
+  ::std::vector<Value> nodes;
+  if (root.is_valid()) nodes.push_back(root);
+  for (const JpSegment &seg : segs) {
+    ::std::vector<Value> next;
+    for (const Value &node : nodes) {
+      if (seg.descendant) {
+        ::std::vector<Value> desc;
+        jp_collect_descendants(node, desc);
+        for (const Value &d : desc)
+          for (const JpSelector &s : seg.selectors) jp_apply_selector(d, s, next);
+      } else {
+        for (const JpSelector &s : seg.selectors) jp_apply_selector(node, s, next);
+      }
+    }
+    nodes = std::move(next);
+  }
+  return nodes;
 }
 
 // ── NDJSON / JSON Lines ──────────────────────────────────────────────────────

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,6 +75,7 @@ add_qbuem_gtest(test_enum)
 add_qbuem_gtest(test_field_rename)
 add_qbuem_gtest(test_ndjson)
 add_qbuem_gtest(test_canonical)
+add_qbuem_gtest(test_jsonpath)
 
 # ── New: dom API type coverage and round-trip fidelity ────────────────────
 add_qbuem_gtest(test_dom_types)

--- a/tests/test_jsonpath.cpp
+++ b/tests/test_jsonpath.cpp
@@ -1,0 +1,102 @@
+// JSONPath (roadmap Tier 2, RFC 9535 structural selectors): root, member, index
+// (incl. negative), wildcard, recursive descent, slices, unions. Filters are not
+// supported (a query with one throws).
+#include <gtest/gtest.h>
+
+#include "qbuem_json/qbuem_json.hpp"
+
+#include <string>
+#include <vector>
+
+namespace {
+const char *kDoc = R"({
+  "store": {
+    "book": [
+      {"category":"ref","author":"Nigel","title":"Sayings","price":8.95},
+      {"category":"fiction","author":"Waugh","title":"Sword","price":12.99},
+      {"category":"fiction","author":"Melville","title":"Moby","price":8.99}
+    ],
+    "bicycle": {"color":"red","price":19.95}
+  },
+  "nums": [10,20,30,40,50]
+})";
+} // namespace
+
+struct JsonPath : ::testing::Test {
+  qbuem::Document doc;
+  qbuem::Value root;
+  void SetUp() override { root = qbuem::parse(doc, kDoc); }
+};
+
+TEST_F(JsonPath, MemberAndIndex) {
+  auto r = qbuem::query(root, "$.store.book[0].title");
+  ASSERT_EQ(r.size(), 1u);
+  EXPECT_EQ(r[0].as<std::string_view>(), "Sayings");
+}
+
+TEST_F(JsonPath, NegativeIndex) {
+  auto r = qbuem::query(root, "$.store.book[-1].author");
+  ASSERT_EQ(r.size(), 1u);
+  EXPECT_EQ(r[0].as<std::string_view>(), "Melville");
+}
+
+TEST_F(JsonPath, WildcardArrayAndObject) {
+  EXPECT_EQ(qbuem::query(root, "$.store.book[*].author").size(), 3u);
+  EXPECT_EQ(qbuem::query(root, "$.store.*").size(), 2u); // book + bicycle
+}
+
+TEST_F(JsonPath, RecursiveDescent) {
+  EXPECT_EQ(qbuem::query(root, "$..price").size(), 4u); // 3 books + bicycle
+  EXPECT_EQ(qbuem::query(root, "$..author").size(), 3u);
+  EXPECT_FALSE(qbuem::query(root, "$..*").empty());
+}
+
+TEST_F(JsonPath, BracketNameWithQuotes) {
+  auto r = qbuem::query(root, "$['store']['bicycle']['color']");
+  ASSERT_EQ(r.size(), 1u);
+  EXPECT_EQ(r[0].as<std::string_view>(), "red");
+}
+
+TEST_F(JsonPath, Slices) {
+  auto a = qbuem::query(root, "$.nums[1:4]");
+  ASSERT_EQ(a.size(), 3u);
+  EXPECT_EQ(a[0].as<int>(), 20);
+  EXPECT_EQ(a[2].as<int>(), 40);
+  EXPECT_EQ(qbuem::query(root, "$.nums[:2]").size(), 2u);
+  auto step = qbuem::query(root, "$.nums[::2]");
+  ASSERT_EQ(step.size(), 3u);
+  EXPECT_EQ(step[2].as<int>(), 50);
+  auto neg = qbuem::query(root, "$.nums[-2:]");
+  ASSERT_EQ(neg.size(), 2u);
+  EXPECT_EQ(neg[0].as<int>(), 40);
+  auto rev = qbuem::query(root, "$.nums[::-1]");
+  ASSERT_EQ(rev.size(), 5u);
+  EXPECT_EQ(rev[0].as<int>(), 50);
+  EXPECT_EQ(rev[4].as<int>(), 10);
+}
+
+TEST_F(JsonPath, Union) {
+  auto r = qbuem::query(root, "$.nums[0, 2, 4]");
+  ASSERT_EQ(r.size(), 3u);
+  EXPECT_EQ(r[0].as<int>(), 10);
+  EXPECT_EQ(r[2].as<int>(), 50);
+}
+
+TEST_F(JsonPath, RootAndNoMatch) {
+  EXPECT_EQ(qbuem::query(root, "$").size(), 1u);
+  EXPECT_TRUE(qbuem::query(root, "$.store.nope").empty());
+  EXPECT_TRUE(qbuem::query(root, "$.nums[99]").empty());
+  EXPECT_TRUE(qbuem::query(root, "$.nums.author").empty()); // type mismatch
+}
+
+TEST_F(JsonPath, MalformedQueryThrows) {
+  EXPECT_THROW((void)qbuem::query(root, "store.x"), qbuem::parse_error);   // no '$'
+  EXPECT_THROW((void)qbuem::query(root, "$.a[1"), qbuem::parse_error);     // unterminated
+  EXPECT_THROW((void)qbuem::query(root, "$.a['x"), qbuem::parse_error);    // unterminated string
+  EXPECT_THROW((void)qbuem::query(root, "$.a[]"), qbuem::parse_error);     // empty selector
+}
+
+TEST_F(JsonPath, FilterSelectorsAreRejected) {
+  EXPECT_THROW((void)qbuem::query(root, "$.store.book[?@.price]"),
+               qbuem::parse_error);
+}


### PR DESCRIPTION
**Roadmap Tier 2 #5.** `qbuem::query(root, path)` returns every Value a JSONPath query selects, in document order — the multi-match query JSON Pointer can't express.

```cpp
qbuem::query(root, "$.store.book[*].author");  // every author
qbuem::query(root, "$..price");                // every price (recursive descent)
qbuem::query(root, "$.store.book[-1].title");  // negative index
qbuem::query(root, "$.nums[1:4]");             // slice; also [::-1], [::2], [-2:]
qbuem::query(root, "$.nums[0, 2, 4]");         // union
```

## Scope (curated)
Supported (RFC 9535 **structural** subset): root `$`, member (`.name`/`['name']`), array index incl. negative, wildcard (`.*`/`[*]`), recursive descent (`..`), slices (`[start:end:step]` with §2.3.4 normalization incl. reverse step), unions.

**Filter expressions (`[?...]`) are explicitly rejected** (throw) — the filter sub-language is a planned follow-up, deliberately not bundled to keep this reviewable and avoid an under-tested expression evaluator (the over-engineering trap).

## Implementation & safety
Recursive-descent path parser (iterative segment loop — every branch consumes or throws, no unbounded loop) + node-list evaluator on Value's existing navigation. Malformed query → `parse_error`; valid no-match → empty.

The parser runs on **untrusted** query strings and traverses untrusted JSON:
- `tests/test_jsonpath.cpp` (10): member/index/negative, wildcard (array+object), recursive descent, bracket+quotes, all slice forms, union, no-match/type-mismatch, malformed-throws, filter-rejected.
- New **`fuzz_jsonpath`** (14th target) splits input into query + JSON doc, drives both; **8M-iter ASan/UBSan clean** locally + in `fuzz.yml`.
- **623/623** pass (Release + ASan/UBSan).

Docs: `parsing.md` JSONPath section, `vision.md` (Tier 2 started), `llms.txt`/full, SEO; version **1.7.0 → 1.8.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)