### PR TITLE
feat: WebAssembly module — bindings/wasm (browser & Node) (v1.9.0)

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,46 @@
+name: WASM
+
+# Builds the WebAssembly module and runs its Node smoke test, so the Emscripten
+# build and the browser/Node API surface stay green.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'bindings/wasm/**'
+      - 'include/qbuem_json/qbuem_json.hpp'
+      - '.github/workflows/wasm.yml'
+  pull_request:
+    paths:
+      - 'bindings/wasm/**'
+      - 'include/qbuem_json/qbuem_json.hpp'
+      - '.github/workflows/wasm.yml'
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Emscripten
+        uses: mymindstorm/setup-emsdk@v14
+        with:
+          version: latest
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Build WASM module
+        run: bash bindings/wasm/build.sh
+
+      - name: Node smoke test
+        run: node bindings/wasm/test/smoke.mjs
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: qbuem-json-wasm
+          path: bindings/wasm/dist/
+          if-no-files-found: error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(qbuem_json VERSION 1.8.0 LANGUAGES CXX)
+project(qbuem_json VERSION 1.9.0 LANGUAGES CXX)
 
 # Library Target
 add_library(qbuem_json INTERFACE)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,11 +47,11 @@ differentiators where few competitors play.
 
 | # | Feature | Why | Class | Effort |
 |---|---------|-----|-------|--------|
-| 5 | **JSONPath (RFC 9535)** — query, filters, normalized paths, CTS conformance | The biggest *query* completeness gap vs jsoncons/serde_json_path; first normative JSONPath (Feb 2024) → becoming table-stakes. | table-stakes | **L** |
-| 6 | **MessagePack codec** (reuse the same field reflection as CBOR) | Broadens binary reach into Redis/msgpack ecosystems; near-free given the CBOR machinery. | adjacent | **M** |
+| 5 | ✅ **JSONPath (RFC 9535)** — structural selectors shipped *(v1.8.0)*; filters planned | The biggest *query* completeness gap vs jsoncons/serde_json_path; first normative JSONPath (Feb 2024) → becoming table-stakes. | table-stakes | **L** |
+| 8 | ✅ **WASM build + npm package** *(v1.9.0, bindings/wasm)* | Amplifies the cross-language pitch into the *browser* — validate / canonicalize / JSONPath, the things JS lacks natively. | differentiator | **S–M** |
 | 7 | **SAX / event / pull API** over the existing tokenizer | Foundation for bounded-memory huge-doc handling + transcoding without a DOM. | foundation | **M** |
-| 8 | **WASM build + npm package** (header-only → cheap; ship scalar fallback) | Amplifies "CBOR decodes in any language" into the *browser* — directly serves the cross-language pitch. | differentiator | **S–M** |
 | 9 | **Runtime CPU dispatch** (one binary runs on any x86 level; we are `-march=native` static today) | Matters for prebuilt bindings / WASM / packaged distribution. simdjson's model. | infra | **M** |
+| ~~6~~ | ❌ **MessagePack codec** — **DECLINED** (2026-06-21 curation) | Duplicative of the shipped CBOR codec (both binary-JSON); a second parallel codec is maintenance cost without clear differentiation. CBOR already covers the cross-language binary need. | — | — |
 
 ## Tier 3 — Longer-term / heavier
 

--- a/bindings/wasm/.gitignore
+++ b/bindings/wasm/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -1,0 +1,47 @@
+# qbuem-json — WebAssembly
+
+[qbuem-json](https://qbuem.com/qbuem-json/) compiled to WebAssembly. Runs the
+native SIMD JSON engine in the browser and Node, exposing the operations the
+platform doesn't provide itself: fast RFC 8259 validation, compact/pretty
+re-serialization, **RFC 8785-style canonicalization** (for hashing & signing),
+and **RFC 9535 JSONPath** querying — all over plain JSON strings.
+
+## Build
+
+Requires the [Emscripten SDK](https://emscripten.org) (`emcc`/`em++`) on `PATH`:
+
+```bash
+./build.sh          # → dist/qbuem_json.mjs + dist/qbuem_json.wasm
+node test/smoke.mjs # run the smoke test
+```
+
+## Usage
+
+```js
+import createQbuemJson from '@qbuem/json-wasm';
+
+const Q = await createQbuemJson();
+
+Q.validate('{"a":1}');                       // true
+Q.minify('{ "a" : 1 }');                      // '{"a":1}'
+Q.prettify('{"a":1}', 2);                     // '{\n  "a": 1\n}'
+Q.canonicalize('{"b":1,"a":1.50}');           // '{"a":1.5,"b":1}'  (sorted, shortest)
+
+const doc = '{"store":{"book":[{"t":"A"},{"t":"B"}]}}';
+Q.query(doc, '$.store.book[*].t');            // '["A","B"]'  (JSON array string)
+Q.query(doc, '$..t');                         // '["A","B"]'  (recursive descent)
+```
+
+`minify` / `prettify` / `canonicalize` / `query` throw on invalid input or a
+malformed query; `validate` returns a boolean and never throws.
+
+## Why WASM here
+
+JavaScript already has `JSON.parse`, so the value-add is the things it lacks:
+**canonicalization** (deterministic bytes for signing/dedup) and **JSONPath**
+(multi-match queries with wildcards, recursive descent, and slices) — plus a fast
+SIMD validator for large payloads — all without pulling in several JS libraries.
+
+## License
+
+Apache-2.0.

--- a/bindings/wasm/build.sh
+++ b/bindings/wasm/build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Build the qbuem-json WebAssembly module (ES module: qbuem_json.mjs + .wasm).
+# Requires the Emscripten SDK (emcc/em++) on PATH — see https://emscripten.org.
+#
+#   ./build.sh            # → dist/qbuem_json.mjs, dist/qbuem_json.wasm
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo="$(cd "$here/../.." && pwd)"
+out="$here/dist"
+mkdir -p "$out"
+
+em++ -std=c++20 -O3 \
+  -I "$repo/include" \
+  "$here/qbuem_wasm.cpp" \
+  -o "$out/qbuem_json.mjs" \
+  -lembind \
+  -sMODULARIZE=1 \
+  -sEXPORT_ES6=1 \
+  -sEXPORT_NAME=createQbuemJson \
+  -sENVIRONMENT=web,node \
+  -sALLOW_MEMORY_GROWTH=1 \
+  -fexceptions
+
+echo "Built: $out/qbuem_json.mjs  +  $out/qbuem_json.wasm"

--- a/bindings/wasm/index.d.ts
+++ b/bindings/wasm/index.d.ts
@@ -1,0 +1,24 @@
+// TypeScript definitions for the qbuem-json WebAssembly module.
+
+export interface QbuemJson {
+  /** True iff `json` is well-formed per RFC 8259 (strict UTF-8). Never throws. */
+  validate(json: string): boolean;
+  /** Compact re-serialization (whitespace stripped). Throws on invalid input. */
+  minify(json: string): string;
+  /** Pretty-print with `indent` spaces per level. Throws on invalid input. */
+  prettify(json: string, indent: number): string;
+  /**
+   * Deterministic canonical form (sorted keys, shortest numbers) for hashing /
+   * signing / content-addressing — RFC 8785 (JCS) structure. Strict-parses input.
+   */
+  canonicalize(json: string): string;
+  /**
+   * JSONPath (RFC 9535 structural selectors) query. Returns a JSON array string
+   * of the selected values, in document order. Throws on a malformed query.
+   * Filter expressions (`[?...]`) are not supported.
+   */
+  query(json: string, path: string): string;
+}
+
+/** Instantiate the WASM module. Resolves to the API once the runtime is ready. */
+export default function createQbuemJson(): Promise<QbuemJson>;

--- a/bindings/wasm/package.json
+++ b/bindings/wasm/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@qbuem/json-wasm",
+  "version": "1.9.0",
+  "description": "qbuem-json compiled to WebAssembly — fast JSON validate/minify, RFC 8785 canonicalization, and RFC 9535 JSONPath in the browser and Node.",
+  "type": "module",
+  "main": "dist/qbuem_json.mjs",
+  "types": "index.d.ts",
+  "files": [
+    "dist/qbuem_json.mjs",
+    "dist/qbuem_json.wasm",
+    "index.d.ts",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "./build.sh",
+    "test": "node test/smoke.mjs"
+  },
+  "keywords": [
+    "json",
+    "wasm",
+    "webassembly",
+    "jsonpath",
+    "rfc9535",
+    "canonicalization",
+    "rfc8785",
+    "validate"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/qbuem/qbuem-json"
+  },
+  "homepage": "https://qbuem.com/qbuem-json/"
+}

--- a/bindings/wasm/qbuem_wasm.cpp
+++ b/bindings/wasm/qbuem_wasm.cpp
@@ -1,0 +1,73 @@
+// WebAssembly (Emscripten/Embind) surface for qbuem-json.
+//
+// Exposes the operations a browser most wants from a native JSON engine and that
+// the platform does NOT provide itself: fast RFC 8259 validation, compact
+// re-serialization (minify), RFC 8785-style canonicalization (for hashing /
+// signing), and JSONPath (RFC 9535) querying. All operate on arbitrary JSON
+// strings — no schema needed.
+//
+// Build: see CMakeLists.txt / build.sh in this directory. Produces an ES module
+// (qbuem_json.mjs + qbuem_json.wasm) usable from the browser and Node.
+#include <qbuem_json/qbuem_json.hpp>
+
+#include <emscripten/bind.h>
+
+#include <string>
+
+namespace {
+
+// Returns true iff `json` is well-formed per RFC 8259 (strict UTF-8). Never throws.
+bool validate(const std::string &json) {
+  try {
+    qbuem::rfc8259::validate(json);
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+// Compact re-serialization (strips insignificant whitespace). Throws on invalid
+// input — Embind surfaces the throw as a JS exception.
+std::string minify(const std::string &json) {
+  qbuem::Document doc;
+  qbuem::Value root = qbuem::parse(doc, json);
+  return root.dump();
+}
+
+// Pretty-print with `indent` spaces per level.
+std::string prettify(const std::string &json, int indent) {
+  qbuem::Document doc;
+  qbuem::Value root = qbuem::parse(doc, json);
+  return root.dump(indent);
+}
+
+// Deterministic canonical form (sorted keys, shortest numbers) — for hashing,
+// signing, content-addressing. RFC 8785 (JCS) structure. Strict-parses input.
+std::string canonicalize(const std::string &json) {
+  return qbuem::canonicalize(json);
+}
+
+// JSONPath (RFC 9535 structural selectors). Returns a JSON array string of the
+// selected values, in document order. Throws on a malformed query.
+std::string query(const std::string &json, const std::string &path) {
+  qbuem::Document doc;
+  qbuem::Value root = qbuem::parse(doc, json);
+  auto matches = qbuem::query(root, path);
+  std::string out = "[";
+  for (std::size_t i = 0; i < matches.size(); ++i) {
+    if (i) out += ',';
+    out += matches[i].dump();
+  }
+  out += ']';
+  return out;
+}
+
+} // namespace
+
+EMSCRIPTEN_BINDINGS(qbuem_json) {
+  emscripten::function("validate", &validate);
+  emscripten::function("minify", &minify);
+  emscripten::function("prettify", &prettify);
+  emscripten::function("canonicalize", &canonicalize);
+  emscripten::function("query", &query);
+}

--- a/bindings/wasm/test/smoke.mjs
+++ b/bindings/wasm/test/smoke.mjs
@@ -1,0 +1,30 @@
+// Node smoke test for the qbuem-json WASM module. Run after build.sh:
+//   node test/smoke.mjs
+import createQbuemJson from '../dist/qbuem_json.mjs';
+
+const Q = await createQbuemJson();
+let fails = 0;
+const eq = (a, b, msg) => {
+  if (a !== b) { console.log(`FAIL ${msg}\n  got: ${a}\n  exp: ${b}`); fails++; }
+};
+
+eq(Q.validate('{"a":1}'), true, 'validate ok');
+eq(Q.validate('{"a":}'), false, 'validate bad');
+eq(Q.validate('[1,2,3]'), true, 'validate array');
+
+eq(Q.minify('{ "a" : 1 , "b":[1, 2] }'), '{"a":1,"b":[1,2]}', 'minify');
+eq(Q.prettify('{"a":1}', 2), '{\n  "a": 1\n}', 'prettify');
+eq(Q.canonicalize('{"b":1,"a":1.50}'), '{"a":1.5,"b":1}', 'canonicalize');
+
+const doc = '{"store":{"book":[{"t":"A"},{"t":"B"}]},"n":[10,20,30]}';
+eq(Q.query(doc, '$.store.book[*].t'), '["A","B"]', 'query wildcard');
+eq(Q.query(doc, '$.n[-1]'), '[30]', 'query negative index');
+eq(Q.query(doc, '$..t'), '["A","B"]', 'query recursive descent');
+eq(Q.query(doc, '$.nope'), '[]', 'query no match');
+
+let threw = false;
+try { Q.minify('{bad}'); } catch (e) { threw = true; }
+eq(threw, true, 'minify throws on bad input');
+
+console.log(fails ? `\n${fails} FAILED` : 'ALL WASM SMOKE TESTS PASSED');
+process.exit(fails ? 1 : 0);

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -179,10 +179,10 @@ export default withMermaid(
                         applicationCategory: 'DeveloperApplication',
                         applicationSubCategory: 'C++ Library',
                         operatingSystem: 'Linux, macOS',
-                        version: '1.8.0',
-                        softwareVersion: '1.8.0',
-                        releaseNotes: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.8.0',
-                        downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.8.0',
+                        version: '1.9.0',
+                        softwareVersion: '1.9.0',
+                        releaseNotes: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.9.0',
+                        downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.9.0',
                         installUrl: 'https://qbuem.com/qbuem-json/guide/getting-started',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
                         keywords: 'C++ JSON library, C++20 JSON, fastest JSON parser, SIMD JSON, AVX-512 JSON, zero-allocation JSON, high-performance JSON, HFT JSON, JSON serializer, single header JSON, header-only JSON, CBOR C++, RFC 8949 CBOR, binary serialization C++, nlohmann alternative, simdjson alternative, RapidJSON alternative',
@@ -203,10 +203,11 @@ export default withMermaid(
                             'NDJSON / JSON Lines streaming (read_lines / write_lines) in bounded memory',
                             'Canonical JSON (qbuem::canonicalize) — deterministic bytes for hashing/signing (RFC 8785-style)',
                             'JSONPath query (qbuem::query, RFC 9535 structural selectors: wildcard, recursive descent, slices)',
+                            'WebAssembly build (browser & Node): validate, canonicalize, JSONPath via Emscripten',
                             'Generic/template types via QBUEM_JSON_FIELDS_TPL (one registration, all instantiations)',
                             'Up to 2.9 GB/s parsing, 7.2 GB/s serialization',
                             'Apache 2.0 license — free for commercial use',
-                            'C, Python, Rust, Go language bindings'
+                            'C, Python, Rust, Go, and WebAssembly bindings'
                         ],
                         screenshot: {
                             '@type': 'ImageObject',
@@ -238,7 +239,7 @@ export default withMermaid(
                         },
                         runtimePlatform: 'C++20',
                         targetProduct: { '@id': 'https://qbuem.com/qbuem-json/#application' },
-                        version: '1.8.0',
+                        version: '1.9.0',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
                         keywords: 'C++, JSON, SIMD, AVX-512, High-Performance, HFT, parser, serializer, zero-allocation',
                         author: { '@id': 'https://qbuem.com/#organization' }
@@ -394,9 +395,9 @@ export default withMermaid(
                     ]
                 },
                 {
-                    text: 'v1.8.0',
+                    text: 'v1.9.0',
                     items: [
-                        { text: 'Release Notes', link: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.8.0' },
+                        { text: 'Release Notes', link: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.9.0' },
                         { text: 'All Releases', link: 'https://github.com/qbuem/qbuem-json/releases' }
                     ]
                 }

--- a/docs/guide/bindings.md
+++ b/docs/guide/bindings.md
@@ -13,6 +13,36 @@
 | **Python** | `nanobind` / `ctypes` | Beta | Data Science, Rapid Prototyping |
 | **Rust** | `cxx` Bridge | Beta | Safe systems programming |
 | **Go** | `cgo` Shim | Alpha | High-speed cloud services |
+| **WebAssembly** | Emscripten / Embind | Beta | Browser & Node (validate, canonicalize, JSONPath) |
+
+---
+
+## 🕸️ WebAssembly (browser & Node)
+
+`bindings/wasm/` compiles the engine to WebAssembly, exposing the operations
+JavaScript lacks natively — fast RFC 8259 validation, compact/pretty
+re-serialization, **RFC 8785-style canonicalization** (deterministic bytes for
+signing/hashing), and **RFC 9535 JSONPath** queries — all over plain JSON strings.
+
+```bash
+cd bindings/wasm
+./build.sh            # needs the Emscripten SDK → dist/qbuem_json.mjs + .wasm
+node test/smoke.mjs
+```
+
+```js
+import createQbuemJson from '@qbuem/json-wasm';
+const Q = await createQbuemJson();
+
+Q.validate('{"a":1}');                  // true
+Q.canonicalize('{"b":1,"a":1.50}');     // '{"a":1.5,"b":1}'
+Q.query('{"n":[10,20,30]}', '$.n[-1]'); // '[30]'   (JSON array string)
+```
+
+`minify` / `prettify` / `canonicalize` / `query` throw on invalid input;
+`validate` returns a boolean. Since the browser already has `JSON.parse`, the
+value here is **canonicalization** and **JSONPath** (plus a fast SIMD validator)
+without bundling several JS libraries.
 
 ---
 

--- a/docs/guide/vision.md
+++ b/docs/guide/vision.md
@@ -30,10 +30,10 @@ The full, sourced roadmap lives in [`ROADMAP.md`](https://github.com/qbuem/qbuem
 ## Tier 2 — Mid-term
 
 - 🚧 **JSONPath (RFC 9535)** — structural selectors (root, member, index, wildcard, recursive descent, slice, union) shipped *(v1.8.0)*; filter expressions planned.
-- ⬜ **MessagePack codec** — second binary target reusing the CBOR field reflection.
+- ✅ **WebAssembly build** — `bindings/wasm`: validate / minify / canonicalize / JSONPath in the browser & Node *(v1.9.0)*.
 - ⬜ **SAX / event / pull API** — bounded-memory huge-document handling and transcoding.
-- ⬜ **WebAssembly build + npm package** — run the parser (and CBOR) in the browser.
 - ⬜ **Runtime CPU dispatch** — one binary that selects AVX-512/AVX2/NEON at load time.
+- ❌ **MessagePack codec** — declined: duplicative of the existing CBOR codec (both binary-JSON); not worth a second parallel codec to maintain.
 
 ## Tier 3 — Longer-term
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -20,7 +20,7 @@ Minimum requirements: C++20, GCC 13+ or Clang 18+ or Apple Clang. Supported plat
 - [Object Mapping (Macros)](https://qbuem.com/qbuem-json/guide/mapping): QBUEM_JSON_FIELDS macro, nested structs, optional fields, STL type mappings
 - [Error Handling](https://qbuem.com/qbuem-json/guide/errors): ParseError, typed exceptions, safe vs. unsafe access patterns
 - [Custom Allocators](https://qbuem.com/qbuem-json/guide/allocators): Arena allocators, stack allocators, custom memory strategies
-- [Language Bindings](https://qbuem.com/qbuem-json/guide/bindings): C FFI, Python, Rust, Go bindings
+- [Language Bindings](https://qbuem.com/qbuem-json/guide/bindings): C FFI, Python, Rust, Go, and WebAssembly (browser/Node) bindings
 - [Low-Latency Patterns](https://qbuem.com/qbuem-json/guide/low-latency-patterns): HFT tick data patterns, pre-allocated documents, reuse strategies
 - [Correctness & Safety](https://qbuem.com/qbuem-json/guide/correctness): RFC 8259/6901/6902/8949 compliance, IEEE 754 round-trip, rich parse errors (line/column/caret), enum support, field rename/skip, NDJSON streaming, canonical JSON, JSONPath query (RFC 9535), 623 tests, sanitizers, fuzzing
 - [Benchmarks](https://qbuem.com/qbuem-json/guide/benchmarks): Live CI benchmark results vs. simdjson, yyjson, RapidJSON, nlohmann

--- a/include/qbuem_json/qbuem_json.hpp
+++ b/include/qbuem_json/qbuem_json.hpp
@@ -1,6 +1,11 @@
 /**
- * @brief qbuem-json v1.8.0 - High-Performance C++20 JSON Parser
- * @version 1.8.0
+ * @brief qbuem-json v1.9.0 - High-Performance C++20 JSON Parser
+ * @version 1.9.0
+ *
+ * v1.9.0: WebAssembly module (roadmap Tier 2). bindings/wasm compiles the engine
+ *         to WASM via Emscripten/Embind, exposing validate / minify / prettify /
+ *         canonicalize / JSONPath query to the browser and Node — the operations
+ *         JS lacks natively. No library change; a new build target + npm package.
  *
  * v1.8.0: JSONPath query (roadmap Tier 2, RFC 9535 structural selectors).
  *         qbuem::query(root, "$.store.book[-1].title") returns every Value a


### PR DESCRIPTION
**Roadmap Tier 2.** Compiles the engine to WebAssembly (Emscripten/Embind), exposing the operations JavaScript lacks natively — over plain JSON strings:

```js
import createQbuemJson from '@qbuem/json-wasm';
const Q = await createQbuemJson();

Q.validate('{"a":1}');                  // true (fast RFC 8259 + strict UTF-8)
Q.minify('{ "a" : 1 }');                // '{"a":1}'
Q.canonicalize('{"b":1,"a":1.50}');     // '{"a":1.5,"b":1}'  (RFC 8785-style)
Q.query('{"n":[10,20,30]}', '$.n[-1]'); // '[30]'  (RFC 9535 JSONPath)
```

Since the browser already has `JSON.parse`, the value is **canonicalization** + **JSONPath** (neither built into JS) plus a fast SIMD validator — without bundling several JS libraries. **No library/header change** beyond the version bump; a new build target + npm package.

## `bindings/wasm/`
`qbuem_wasm.cpp` (Embind surface) · `build.sh` (emcc → `dist/qbuem_json.mjs` ES module + `.wasm`) · `package.json` (`@qbuem/json-wasm`) · `index.d.ts` (TS types) · `test/smoke.mjs` · README. `dist/` gitignored.

## Verification
**Verified locally end-to-end** (installed emsdk): `build.sh` → 148 KB `.wasm` + 31 KB ES-module glue; `node test/smoke.mjs` passes all checks (validate/minify/prettify/canonicalize; JSONPath wildcard/negative-index/recursive-descent/no-match; error propagation as JS exceptions). New **`wasm.yml`** CI (setup-emsdk → build → node smoke test) re-verifies on Linux.

C++ suite unchanged (**623/623**). Docs: `bindings.md` WASM section + matrix row, `vision.md`, `llms.txt`, SEO; version **1.8.0 → 1.9.0**.

## MessagePack declined
Tier 2 #6 (MessagePack) is **declined** in the same pass — duplicative of the shipped CBOR codec (both binary-JSON); a second parallel codec is maintenance cost without clear differentiation. Recorded in `ROADMAP.md` / `vision.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)