### PR TITLE
feat: SAX-style event visitor — qbuem::visit / sax_parse (v1.10.0)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -63,7 +63,7 @@ jobs:
         status=0
         for t in fuzz_parse fuzz_dom fuzz_nexus fuzz_direct fuzz_pmr \
                  fuzz_patch fuzz_api_stress fuzz_rfc8259 fuzz_float fuzz_cbor \
-                 fuzz_ndjson fuzz_jsonpath; do
+                 fuzz_ndjson fuzz_jsonpath fuzz_sax; do
           echo "::group::$t (${SECS}s)"
           if ! ./build-fuzz/fuzz/$t fuzz/corpus -dict=fuzz/json.dict \
                  -max_len=65536 -rss_limit_mb=4096 -max_total_time=$SECS \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(qbuem_json VERSION 1.9.0 LANGUAGES CXX)
+project(qbuem_json VERSION 1.10.0 LANGUAGES CXX)
 
 # Library Target
 add_library(qbuem_json INTERFACE)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -179,10 +179,10 @@ export default withMermaid(
                         applicationCategory: 'DeveloperApplication',
                         applicationSubCategory: 'C++ Library',
                         operatingSystem: 'Linux, macOS',
-                        version: '1.9.0',
-                        softwareVersion: '1.9.0',
-                        releaseNotes: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.9.0',
-                        downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.9.0',
+                        version: '1.10.0',
+                        softwareVersion: '1.10.0',
+                        releaseNotes: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.10.0',
+                        downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.10.0',
                         installUrl: 'https://qbuem.com/qbuem-json/guide/getting-started',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
                         keywords: 'C++ JSON library, C++20 JSON, fastest JSON parser, SIMD JSON, AVX-512 JSON, zero-allocation JSON, high-performance JSON, HFT JSON, JSON serializer, single header JSON, header-only JSON, CBOR C++, RFC 8949 CBOR, binary serialization C++, nlohmann alternative, simdjson alternative, RapidJSON alternative',
@@ -196,7 +196,7 @@ export default withMermaid(
                             'RFC 8259, RFC 6901, RFC 6902, RFC 8949, RFC 9535 (JSONPath) compliant',
                             'IEEE 754 round-trip float correctness',
                             'Rich parse errors: line/column/offset + caret rendering (format_error)',
-                            '623 passing tests, 14 libFuzzer targets',
+                            '631 passing tests, 15 libFuzzer targets',
                             'STL container support (vector, map, optional, tuple, variant)',
                             'Enum support: integer by default, value-name via QBUEM_JSON_ENUM (JSON + CBOR)',
                             'Field rename (member, "jsonKey") and skip-by-omission, across JSON/fuse/CBOR',
@@ -204,6 +204,7 @@ export default withMermaid(
                             'Canonical JSON (qbuem::canonicalize) — deterministic bytes for hashing/signing (RFC 8785-style)',
                             'JSONPath query (qbuem::query, RFC 9535 structural selectors: wildcard, recursive descent, slices)',
                             'WebAssembly build (browser & Node): validate, canonicalize, JSONPath via Emscripten',
+                            'SAX-style event visitor (qbuem::visit / sax_parse) for transcoding & inspection',
                             'Generic/template types via QBUEM_JSON_FIELDS_TPL (one registration, all instantiations)',
                             'Up to 2.9 GB/s parsing, 7.2 GB/s serialization',
                             'Apache 2.0 license — free for commercial use',
@@ -239,7 +240,7 @@ export default withMermaid(
                         },
                         runtimePlatform: 'C++20',
                         targetProduct: { '@id': 'https://qbuem.com/qbuem-json/#application' },
-                        version: '1.9.0',
+                        version: '1.10.0',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
                         keywords: 'C++, JSON, SIMD, AVX-512, High-Performance, HFT, parser, serializer, zero-allocation',
                         author: { '@id': 'https://qbuem.com/#organization' }
@@ -395,9 +396,9 @@ export default withMermaid(
                     ]
                 },
                 {
-                    text: 'v1.9.0',
+                    text: 'v1.10.0',
                     items: [
-                        { text: 'Release Notes', link: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.9.0' },
+                        { text: 'Release Notes', link: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.10.0' },
                         { text: 'All Releases', link: 'https://github.com/qbuem/qbuem-json/releases' }
                     ]
                 }

--- a/docs/guide/parsing.md
+++ b/docs/guide/parsing.md
@@ -369,6 +369,36 @@ into the same document as `root`, so keep the document alive.
 
 ---
 
+## 🎬 SAX-style Event Visitor
+
+`qbuem::visit(value, handler)` walks a parsed document depth-first and emits an
+event for each node — for **transcoding, inspection, or folds** without
+navigating the DOM by hand. Derive a handler from `qbuem::sax_handler` and
+override only the events you want (the rest default to no-ops); dispatch is static
+(no virtuals → zero overhead). Return `false` from any event to **abort** the walk.
+
+```cpp
+struct PriceSum : qbuem::sax_handler {
+    double total = 0;
+    bool key(std::string_view k) { want = (k == "price"); return true; }
+    bool real(double v)    { if (want) total += v; want = false; return true; }
+    bool integer(int64_t v){ if (want) total += v; want = false; return true; }
+    bool want = false;
+};
+
+PriceSum h;
+qbuem::sax_parse(json, h);     // parse + visit in one call
+// or: qbuem::visit(alreadyParsedValue, h);
+std::cout << h.total << '\n';
+```
+
+This is an event walk over the proven tape parser — **not** a second streaming
+parser. For data larger than RAM, use [NDJSON](/guide/serialization#ndjson-json-lines)
+(`read_lines`). String/key values are the raw on-the-wire slice (zero-copy),
+matching `as<std::string_view>()`.
+
+---
+
 ## ⚠️ Common Pitfalls
 
 ### 1. Doc Must Outlive Values

--- a/docs/guide/vision.md
+++ b/docs/guide/vision.md
@@ -31,7 +31,7 @@ The full, sourced roadmap lives in [`ROADMAP.md`](https://github.com/qbuem/qbuem
 
 - 🚧 **JSONPath (RFC 9535)** — structural selectors (root, member, index, wildcard, recursive descent, slice, union) shipped *(v1.8.0)*; filter expressions planned.
 - ✅ **WebAssembly build** — `bindings/wasm`: validate / minify / canonicalize / JSONPath in the browser & Node *(v1.9.0)*.
-- ⬜ **SAX / event / pull API** — bounded-memory huge-document handling and transcoding.
+- ✅ **SAX-style event visitor** — `qbuem::visit` / `sax_parse` for transcoding & inspection *(v1.10.0)*.
 - ⬜ **Runtime CPU dispatch** — one binary that selects AVX-512/AVX2/NEON at load time.
 - ❌ **MessagePack codec** — declined: duplicative of the existing CBOR codec (both binary-JSON); not worth a second parallel codec to maintain.
 

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -22,7 +22,7 @@ Minimum requirements: C++20, GCC 13+ or Clang 18+ or Apple Clang. Supported plat
 - [Custom Allocators](https://qbuem.com/qbuem-json/guide/allocators): Arena allocators, stack allocators, custom memory strategies
 - [Language Bindings](https://qbuem.com/qbuem-json/guide/bindings): C FFI, Python, Rust, Go, and WebAssembly (browser/Node) bindings
 - [Low-Latency Patterns](https://qbuem.com/qbuem-json/guide/low-latency-patterns): HFT tick data patterns, pre-allocated documents, reuse strategies
-- [Correctness & Safety](https://qbuem.com/qbuem-json/guide/correctness): RFC 8259/6901/6902/8949 compliance, IEEE 754 round-trip, rich parse errors (line/column/caret), enum support, field rename/skip, NDJSON streaming, canonical JSON, JSONPath query (RFC 9535), 623 tests, sanitizers, fuzzing
+- [Correctness & Safety](https://qbuem.com/qbuem-json/guide/correctness): RFC 8259/6901/6902/8949 compliance, IEEE 754 round-trip, rich parse errors (line/column/caret), enum support, field rename/skip, NDJSON streaming, canonical JSON, JSONPath query (RFC 9535), SAX event visitor, 631 tests, sanitizers, fuzzing
 - [Benchmarks](https://qbuem.com/qbuem-json/guide/benchmarks): Live CI benchmark results vs. simdjson, yyjson, RapidJSON, nlohmann
 - [Vision & Roadmap](https://qbuem.com/qbuem-json/guide/vision): Project goals and planned features
 

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -64,3 +64,4 @@ add_fuzz_target(fuzz_patch)      # JSON Pointer & Mutation stress test
 add_fuzz_target(fuzz_cbor)       # CBOR codec: decode hostile bytes + round-trip
 add_fuzz_target(fuzz_ndjson)     # NDJSON line splitter + sub-view parse safety
 add_fuzz_target(fuzz_jsonpath)   # JSONPath query parser + evaluator on untrusted input
+add_fuzz_target(fuzz_sax)        # SAX event visitor recursion + handler dispatch

--- a/fuzz/fuzz_sax.cpp
+++ b/fuzz/fuzz_sax.cpp
@@ -1,0 +1,45 @@
+// fuzz_sax — SAX event visitor over arbitrary (fuzzer-controlled) JSON.
+// visit() recurses to the JSON's nesting depth (bounded by the parser's depth
+// limit) and reuses the already-fuzzed Value iteration; this target confirms the
+// recursive walk + handler dispatch stay safe on hostile input, including an
+// early-abort handler that stops mid-walk.
+#include <qbuem_json/qbuem_json.hpp>
+
+#include <cstdint>
+#include <string>
+
+namespace {
+// Touches every event and aborts pseudo-randomly to exercise early-exit paths.
+struct FuzzHandler : qbuem::sax_handler {
+  uint32_t budget;
+  explicit FuzzHandler(uint32_t b) : budget(b) {}
+  bool tick() { return budget-- != 0; }
+  bool start_object() { return tick(); }
+  bool end_object(size_t) { return tick(); }
+  bool start_array() { return tick(); }
+  bool end_array(size_t) { return tick(); }
+  bool key(std::string_view k) { sink ^= k.size(); return tick(); }
+  bool string(std::string_view s) { sink ^= s.size(); return tick(); }
+  bool integer(int64_t i) { sink ^= static_cast<size_t>(i); return tick(); }
+  bool real(double) { return tick(); }
+  bool boolean(bool) { return tick(); }
+  bool null() { return tick(); }
+  size_t sink = 0;
+};
+} // namespace
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  std::string_view in(reinterpret_cast<const char *>(data), size);
+
+  // Derive an abort budget from the first byte so some walks stop early.
+  const uint32_t budget = size ? (static_cast<uint32_t>(data[0]) * 4u + 1u) : 1u;
+
+  try {
+    qbuem::Document doc;
+    qbuem::Value root = qbuem::parse(doc, in);
+    FuzzHandler h(budget);
+    (void)qbuem::visit(root, h);
+  } catch (const std::exception &) {
+  }
+  return 0;
+}

--- a/include/qbuem_json/qbuem_json.hpp
+++ b/include/qbuem_json/qbuem_json.hpp
@@ -1,6 +1,14 @@
 /**
- * @brief qbuem-json v1.9.0 - High-Performance C++20 JSON Parser
- * @version 1.9.0
+ * @brief qbuem-json v1.10.0 - High-Performance C++20 JSON Parser
+ * @version 1.10.0
+ *
+ * v1.10.0: SAX-style event visitor (roadmap Tier 2). qbuem::visit(value, handler)
+ *          and sax_parse(json, handler) walk a document depth-first, emitting an
+ *          event per node (start_object/key/string/integer/…) to a handler
+ *          derived from qbuem::sax_handler — for transcoding / inspection / folds
+ *          without hand-navigating the DOM. Static dispatch (no virtuals); a
+ *          handler returning false aborts the walk. An event walk over the proven
+ *          tape parser, not a second parser (use NDJSON for data larger than RAM).
  *
  * v1.9.0: WebAssembly module (roadmap Tier 2). bindings/wasm compiles the engine
  *         to WASM via Emscripten/Embind, exposing validate / minify / prettify /
@@ -10512,6 +10520,74 @@ inline void canon_emit_(const json::Value &v, ::std::string &out) {
   out.reserve(json.size());
   canon_emit_(root, out);
   return out;
+}
+
+// ── SAX-style event visitor ──────────────────────────────────────────────────
+// qbuem::visit(value, handler) walks a parsed Value depth-first and emits an
+// event for each node to `handler`, so you can transcode / inspect / fold JSON
+// without navigating the DOM by hand.  This is an event walk over the (proven,
+// fuzzed) tape parser — not a separate streaming parser; for data larger than
+// RAM use NDJSON (read_lines).
+//
+// Derive a handler from qbuem::sax_handler and override only the events you care
+// about; the rest default to no-ops.  Dispatch is static (no virtuals → zero
+// overhead).  Every handler method returns bool — return false to ABORT the walk
+// early (visit then returns false).  String/key values are the RAW on-the-wire
+// slice (escaped, zero-copy), matching Value::as<std::string_view>(); decode with
+// the value's own escapes if you need the logical text.
+struct sax_handler {
+  bool start_object() { return true; }
+  bool end_object(::std::size_t /*member_count*/) { return true; }
+  bool start_array() { return true; }
+  bool end_array(::std::size_t /*element_count*/) { return true; }
+  bool key(::std::string_view /*raw*/) { return true; }
+  bool string(::std::string_view /*raw*/) { return true; }
+  bool integer(int64_t) { return true; }
+  bool real(double) { return true; }
+  bool boolean(bool) { return true; }
+  bool null() { return true; }
+};
+
+// Walk `v`, dispatching events to `h`.  Returns false iff a handler aborted.
+template <typename H>
+bool visit(const Value &v, H &h) {
+  if (v.is_object()) {
+    if (!h.start_object()) return false;
+    ::std::size_t n = 0;
+    for (const auto &[k, val] : v.items()) {
+      if (!h.key(k)) return false;
+      if (!visit(val, h)) return false;
+      ++n;
+    }
+    return h.end_object(n);
+  } else if (v.is_array()) {
+    if (!h.start_array()) return false;
+    ::std::size_t n = 0;
+    for (const auto &e : v.elements()) {
+      if (!visit(e, h)) return false;
+      ++n;
+    }
+    return h.end_array(n);
+  } else if (v.is_string()) {
+    return h.string(v.template as<::std::string_view>());
+  } else if (v.is_int()) {
+    return h.integer(v.template as<int64_t>());
+  } else if (v.is_double()) {
+    return h.real(v.template as<double>());
+  } else if (v.is_bool()) {
+    return h.boolean(v.template as<bool>());
+  } else {
+    return h.null();
+  }
+}
+
+// Parse `json` then visit it — the "stream events from text" one-liner. Throws
+// qbuem::parse_error on invalid input. Returns false iff a handler aborted.
+template <typename H>
+bool sax_parse(::std::string_view json, H &h) {
+  Document doc;
+  Value root = parse(doc, json);
+  return visit(root, h);
 }
 
 // ── JSONPath (RFC 9535 — structural selectors) ───────────────────────────────

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,6 +76,7 @@ add_qbuem_gtest(test_field_rename)
 add_qbuem_gtest(test_ndjson)
 add_qbuem_gtest(test_canonical)
 add_qbuem_gtest(test_jsonpath)
+add_qbuem_gtest(test_sax)
 
 # ── New: dom API type coverage and round-trip fidelity ────────────────────
 add_qbuem_gtest(test_dom_types)

--- a/tests/test_sax.cpp
+++ b/tests/test_sax.cpp
@@ -1,0 +1,83 @@
+// SAX-style event visitor (roadmap Tier 2): qbuem::visit / sax_parse walk a
+// parsed document depth-first, emitting an event per node to a handler derived
+// from qbuem::sax_handler. Static dispatch (no virtuals); a handler returning
+// false aborts the walk.
+#include <gtest/gtest.h>
+
+#include "qbuem_json/qbuem_json.hpp"
+
+#include <cstdint>
+#include <string>
+
+namespace {
+// Serializes the event stream to a compact log for exact-match assertions.
+struct Recorder : qbuem::sax_handler {
+  std::string log;
+  bool start_object() { log += "{"; return true; }
+  bool end_object(size_t n) { log += "}" + std::to_string(n); return true; }
+  bool start_array() { log += "["; return true; }
+  bool end_array(size_t n) { log += "]" + std::to_string(n); return true; }
+  bool key(std::string_view k) { log += "k:"; log.append(k); log += ";"; return true; }
+  bool string(std::string_view s) { log += "s:"; log.append(s); log += ";"; return true; }
+  bool integer(int64_t i) { log += "i:" + std::to_string(i) + ";"; return true; }
+  bool real(double) { log += "r;"; return true; }
+  bool boolean(bool b) { log += b ? "T;" : "F;"; return true; }
+  bool null() { log += "N;"; return true; }
+};
+} // namespace
+
+TEST(Sax, FullEventStream) {
+  Recorder r;
+  ASSERT_TRUE(qbuem::sax_parse(R"({"a":1,"b":[true,null,"x"],"c":2.5})", r));
+  EXPECT_EQ(r.log, "{k:a;i:1;k:b;[T;N;s:x;]3k:c;r;}3");
+}
+
+TEST(Sax, VisitParsedValue) {
+  qbuem::Document d;
+  auto root = qbuem::parse(d, "[1,2,3]");
+  Recorder r;
+  EXPECT_TRUE(qbuem::visit(root, r));
+  EXPECT_EQ(r.log, "[i:1;i:2;i:3;]3");
+}
+
+TEST(Sax, MemberAndElementCounts) {
+  Recorder r;
+  qbuem::sax_parse(R"({"x":{},"y":[1,2]})", r);
+  EXPECT_EQ(r.log, "{k:x;{}0k:y;[i:1;i:2;]2}2");
+}
+
+TEST(Sax, DefaultHandlerIsNoOp) {
+  // A handler that overrides nothing walks without error and counts via return.
+  qbuem::sax_handler h;
+  EXPECT_TRUE(qbuem::sax_parse(R"({"a":[1,{"b":2}],"c":null})", h));
+}
+
+TEST(Sax, AbortStopsTheWalk) {
+  struct Aborter : qbuem::sax_handler {
+    int keys = 0;
+    bool key(std::string_view) { ++keys; return false; } // abort on first key
+  } a;
+  EXPECT_FALSE(qbuem::sax_parse(R"({"a":1,"b":2})", a));
+  EXPECT_EQ(a.keys, 1);
+}
+
+TEST(Sax, AbortInsideNestedArray) {
+  struct Counter : qbuem::sax_handler {
+    int ints = 0;
+    bool integer(int64_t) { ++ints; return ints < 2; } // abort on 2nd integer
+  } c;
+  EXPECT_FALSE(qbuem::sax_parse("[1,2,3,4]", c));
+  EXPECT_EQ(c.ints, 2);
+}
+
+TEST(Sax, TopLevelScalars) {
+  Recorder r1; qbuem::sax_parse("42", r1);  EXPECT_EQ(r1.log, "i:42;");
+  Recorder r2; qbuem::sax_parse("true", r2); EXPECT_EQ(r2.log, "T;");
+  Recorder r3; qbuem::sax_parse("null", r3); EXPECT_EQ(r3.log, "N;");
+  Recorder r4; qbuem::sax_parse("\"hi\"", r4); EXPECT_EQ(r4.log, "s:hi;");
+}
+
+TEST(Sax, InvalidInputThrows) {
+  Recorder r;
+  EXPECT_THROW((void)qbuem::sax_parse("{bad}", r), qbuem::parse_error);
+}


### PR DESCRIPTION
**Roadmap Tier 2 #7.** `qbuem::visit(value, handler)` walks a parsed document depth-first and emits an event per node — for **transcoding, inspection, folds** without hand-navigating the DOM. `sax_parse(json, handler)` is the parse-then-visit one-liner.

```cpp
struct PriceSum : qbuem::sax_handler {
    double total = 0; bool want = false;
    bool key(std::string_view k) { want = (k == "price"); return true; }
    bool real(double v)     { if (want) total += v; want = false; return true; }
    bool integer(int64_t v) { if (want) total += v; want = false; return true; }
};
PriceSum h; qbuem::sax_parse(json, h);   // h.total
```

## Curated scope (user-directed)
This is an **event walk over the existing, proven, fuzzed tape parser** — *not* a second streaming parser. The bounded-memory streaming-parser version was **declined** to avoid maintaining two parsers (the over-engineering trap); NDJSON (`read_lines`) already covers data larger than RAM.

## Design
Derive from `qbuem::sax_handler`, override only the events you want (rest default to no-op). **Static dispatch** — base methods are non-virtual; `visit<H>` calls the derived type's methods directly → unoverridden events cost nothing, no virtuals. Any event returns `false` to **abort**. Recursion bounded by JSON depth (parser-capped). String/key = raw zero-copy slice.

## Verification
- `tests/test_sax.cpp` (8): exact event stream, visit over parsed Value, member/element counts, default no-op handler, abort (key + nested array), top-level scalars, invalid-throws.
- New **`fuzz_sax`** (15th target) walks arbitrary parsed JSON with an early-abort handler; **8M-iter ASan/UBSan clean** locally + in `fuzz.yml`.
- **631/631** pass (Release + ASan/UBSan). Docs: `parsing.md` SAX section, `vision.md`, `llms.txt`, SEO; version **1.9.0 → 1.10.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)