### PR TITLE
docs: close out Tier 2 — portable-build guide; decline runtime CPU dispatch

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,8 +49,8 @@ differentiators where few competitors play.
 |---|---------|-----|-------|--------|
 | 5 | ✅ **JSONPath (RFC 9535)** — structural selectors shipped *(v1.8.0)*; filters planned | The biggest *query* completeness gap vs jsoncons/serde_json_path; first normative JSONPath (Feb 2024) → becoming table-stakes. | table-stakes | **L** |
 | 8 | ✅ **WASM build + npm package** *(v1.9.0, bindings/wasm)* | Amplifies the cross-language pitch into the *browser* — validate / canonicalize / JSONPath, the things JS lacks natively. | differentiator | **S–M** |
-| 7 | **SAX / event / pull API** over the existing tokenizer | Foundation for bounded-memory huge-doc handling + transcoding without a DOM. | foundation | **M** |
-| 9 | **Runtime CPU dispatch** (one binary runs on any x86 level; we are `-march=native` static today) | Matters for prebuilt bindings / WASM / packaged distribution. simdjson's model. | infra | **M** |
+| 7 | ✅ **SAX-style event visitor** *(v1.10.0, `visit` / `sax_parse`)* — event walk over the tape parser (not a second streaming parser) | Transcoding / inspection / folds without hand-navigating the DOM. | foundation | **M** |
+| ~~9~~ | ❌ **Runtime CPU dispatch** — **DECLINED** (2026-06-21 curation) | Header-only consumers recompile (`-march=native` → optimal SIMD free); a multi-versioned dispatcher in the core hot path is high regression risk for a benefit only prebuilt artifacts see. Shipped a portable-vs-native build guide instead. | — | — |
 | ~~6~~ | ❌ **MessagePack codec** — **DECLINED** (2026-06-21 curation) | Duplicative of the shipped CBOR codec (both binary-JSON); a second parallel codec is maintenance cost without clear differentiation. CBOR already covers the cross-language binary need. | — | — |
 
 ## Tier 3 — Longer-term / heavier

--- a/docs/guide/bindings.md
+++ b/docs/guide/bindings.md
@@ -46,6 +46,29 @@ without bundling several JS libraries.
 
 ---
 
+## 📦 Portable vs. native builds (for distributing prebuilt bindings)
+
+qbuem-json picks its SIMD path **at compile time**, so a binary is tuned for the
+ISA it was built against. When you *recompile in your own project* (the normal
+header-only path), `-march=native` already gives the optimal kernel for that
+machine — nothing else to do.
+
+When you **distribute a prebuilt artifact** (a Python wheel, a Rust/Go shared
+lib), choose deliberately:
+
+| Goal | Build flags | Trade-off |
+|:---|:---|:---|
+| **Maximum speed**, known target | `-march=native` (or `-mavx2` / `-march=skylake-avx512`) | Fastest; **crashes** (illegal instruction) on a CPU lacking that ISA. |
+| **Maximum compatibility**, any x86-64 | `-mssse3` / baseline `x86-64` (SWAR fallback) | Runs everywhere; gives up wide-SIMD throughput. |
+| **Both** | Ship one artifact per ISA tier and select at install/load time | Most work; what manylinux wheels and distro packages do. |
+
+There is intentionally **no runtime CPU dispatch baked into the header** — for a
+header-only library the recompile path already yields optimal SIMD, and baking a
+multi-versioned dispatcher into the core hot path would add risk for a benefit
+only prebuilt artifacts see. Pick the build that matches how you ship.
+
+---
+
 ## 🛠 Usage Guides
 
 ### 1. Stable C API (`bindings/c/`)

--- a/docs/guide/vision.md
+++ b/docs/guide/vision.md
@@ -32,8 +32,8 @@ The full, sourced roadmap lives in [`ROADMAP.md`](https://github.com/qbuem/qbuem
 - 🚧 **JSONPath (RFC 9535)** — structural selectors (root, member, index, wildcard, recursive descent, slice, union) shipped *(v1.8.0)*; filter expressions planned.
 - ✅ **WebAssembly build** — `bindings/wasm`: validate / minify / canonicalize / JSONPath in the browser & Node *(v1.9.0)*.
 - ✅ **SAX-style event visitor** — `qbuem::visit` / `sax_parse` for transcoding & inspection *(v1.10.0)*.
-- ⬜ **Runtime CPU dispatch** — one binary that selects AVX-512/AVX2/NEON at load time.
 - ❌ **MessagePack codec** — declined: duplicative of the existing CBOR codec (both binary-JSON); not worth a second parallel codec to maintain.
+- ❌ **Runtime CPU dispatch** — declined: a header-only library is recompiled per project (`-march=native` → optimal SIMD for free); baking a multi-versioned dispatcher into the core hot path is high risk for a benefit only prebuilt artifacts see. See the [portable-vs-native build guide](/guide/bindings#portable-vs-native-builds-for-distributing-prebuilt-bindings) instead.
 
 ## Tier 3 — Longer-term
 


### PR DESCRIPTION
Tier 2 complete (JSONPath v1.8.0, WASM v1.9.0, SAX v1.10.0). Records the two curation declines (MessagePack, runtime CPU dispatch) with rationale and adds a **Portable vs. native builds** guide to bindings.md for distributing prebuilt artifacts. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)