### PR TITLE
feat: packaging — fix find_package, add Conan recipe + vcpkg port (v1.11.1)

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,0 +1,73 @@
+name: Packaging
+
+# Verifies the library is consumable the way packagers ship it: a CMake
+# install + downstream find_package, and a Conan create (recipe + test_package).
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'CMakeLists.txt'
+      - 'cmake/**'
+      - 'conanfile.py'
+      - 'test_package/**'
+      - 'ports/**'
+      - 'include/qbuem_json/qbuem_json.hpp'
+      - '.github/workflows/packaging.yml'
+  pull_request:
+    paths:
+      - 'CMakeLists.txt'
+      - 'cmake/**'
+      - 'conanfile.py'
+      - 'test_package/**'
+      - 'ports/**'
+      - 'include/qbuem_json/qbuem_json.hpp'
+      - '.github/workflows/packaging.yml'
+  workflow_dispatch:
+
+jobs:
+  cmake-install:
+    name: CMake install + find_package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install + export
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_INSTALL_PREFIX="$PWD/_install" \
+            -DQBUEM_JSON_BUILD_TESTS=OFF \
+            -DQBUEM_JSON_BUILD_BENCHMARKS=OFF
+          cmake --install build
+      - name: Consume via find_package
+        run: |
+          mkdir -p consumer && cd consumer
+          cat > CMakeLists.txt <<'EOF'
+          cmake_minimum_required(VERSION 3.14)
+          project(consumer CXX)
+          find_package(qbuem_json CONFIG REQUIRED)
+          add_executable(app main.cpp)
+          target_link_libraries(app PRIVATE qbuem_json::qbuem_json)
+          target_compile_features(app PRIVATE cxx_std_20)
+          EOF
+          cat > main.cpp <<'EOF'
+          #include <qbuem_json/qbuem_json.hpp>
+          #include <cstdio>
+          int main(){ auto j = qbuem::canonicalize(std::string_view("{\"b\":1,\"a\":2}")); std::printf("%s\n", j.c_str()); return j == "{\"a\":2,\"b\":1}" ? 0 : 1; }
+          EOF
+          cmake -S . -B build -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/_install"
+          cmake --build build
+          ./build/app
+
+  conan:
+    name: Conan create
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Conan
+        run: pip install "conan>=2.0"
+      - name: conan create
+        run: |
+          conan profile detect --force
+          conan create . -s compiler.cppstd=20 --build=missing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(qbuem_json VERSION 1.11.0 LANGUAGES CXX)
+project(qbuem_json VERSION 1.11.1 LANGUAGES CXX)
 
 # Library Target
 add_library(qbuem_json INTERFACE)
@@ -51,8 +51,16 @@ write_basic_package_version_file(
     COMPATIBILITY SameMajorVersion
 )
 
+# Generate the package config so `find_package(qbuem_json CONFIG)` works downstream.
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/qbuem_jsonConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/qbuem_jsonConfig.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/qbuem_json
+)
+
 install(FILES
-    "qbuem_jsonConfigVersion.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/qbuem_jsonConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/qbuem_jsonConfigVersion.cmake"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/qbuem_json
 )
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@
     <a href="https://github.com/qbuem/qbuem-json/actions/workflows/sanitizers.yml"><img src="https://github.com/qbuem/qbuem-json/actions/workflows/sanitizers.yml/badge.svg" alt="Sanitizers (ASan · UBSan · TSan)"></a>
     <a href="https://github.com/qbuem/qbuem-json/actions/workflows/benchmark.yml"><img src="https://github.com/qbuem/qbuem-json/actions/workflows/benchmark.yml/badge.svg" alt="Benchmark CI"></a>
     <a href="https://github.com/qbuem/qbuem-json/actions/workflows/codeql.yml"><img src="https://github.com/qbuem/qbuem-json/actions/workflows/codeql.yml/badge.svg" alt="CodeQL"></a>
+    <a href="https://github.com/qbuem/qbuem-json/actions/workflows/packaging.yml"><img src="https://github.com/qbuem/qbuem-json/actions/workflows/packaging.yml/badge.svg" alt="Packaging (CMake · Conan)"></a>
+  </p>
+
+  <!-- Distribution -->
+  <p>
+    <img src="https://img.shields.io/badge/header--only-single%20file-blue" alt="single-header">
+    <img src="https://img.shields.io/badge/CMake-find__package-064F8C" alt="CMake find_package">
+    <img src="https://img.shields.io/badge/Conan-recipe-6699cb" alt="Conan recipe">
+    <img src="https://img.shields.io/badge/vcpkg-overlay%20port-2596be" alt="vcpkg port">
+    <img src="https://img.shields.io/badge/WASM-browser%20%26%20Node-654ff0" alt="WebAssembly">
   </p>
 
   <!-- Compliance & Standards -->

--- a/cmake/qbuem_jsonConfig.cmake.in
+++ b/cmake/qbuem_jsonConfig.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+# qbuem-json is a header-only INTERFACE library with zero external dependencies,
+# so the package config only needs to pull in the exported target.
+include("${CMAKE_CURRENT_LIST_DIR}/qbuem_jsonTargets.cmake")
+
+check_required_components(qbuem_json)

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,43 @@
+import os
+from conan import ConanFile
+from conan.tools.files import copy
+from conan.tools.build import check_min_cppstd
+
+
+class QbuemJsonConan(ConanFile):
+    name = "qbuem-json"
+    version = "1.11.1"
+    license = "Apache-2.0"
+    url = "https://github.com/qbuem/qbuem-json"
+    homepage = "https://qbuem.com/qbuem-json/"
+    description = (
+        "Single-header C++20 JSON library: dual-engine SIMD DOM + zero-tape "
+        "struct mapping, CBOR (RFC 8949), JSONPath (RFC 9535), canonicalization "
+        "(RFC 8785), JSON diff/patch (RFC 6902). Zero dependencies."
+    )
+    topics = ("json", "cbor", "jsonpath", "simd", "header-only", "cpp20",
+              "serialization", "rfc8259")
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+    exports_sources = "include/*", "LICENSE"
+
+    def validate(self):
+        check_min_cppstd(self, 20)
+
+    def package_id(self):
+        self.info.clear()  # header-only — one package for all configurations
+
+    def package(self):
+        copy(self, "*.hpp",
+             src=os.path.join(self.source_folder, "include"),
+             dst=os.path.join(self.package_folder, "include"))
+        copy(self, "LICENSE", src=self.source_folder,
+             dst=os.path.join(self.package_folder, "licenses"))
+
+    def package_info(self):
+        # Match the upstream CMake package so `find_package(qbuem_json)` +
+        # `qbuem_json::qbuem_json` work identically under Conan.
+        self.cpp_info.set_property("cmake_file_name", "qbuem_json")
+        self.cpp_info.set_property("cmake_target_name", "qbuem_json::qbuem_json")
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -61,7 +61,29 @@ cmake --install build --prefix /usr/local
 After install, link in your CMakeLists:
 
 ```cmake
-find_package(qbuem_json REQUIRED)
+find_package(qbuem_json CONFIG REQUIRED)
+target_link_libraries(your_target PRIVATE qbuem_json::qbuem_json)
+```
+
+### Option D: Package managers
+
+**Conan** — a recipe ships in the repo (`conanfile.py`):
+
+```bash
+conan create . -s compiler.cppstd=20      # build & test the package locally
+# in your conanfile: requires = "qbuem-json/1.11.1"
+```
+
+**vcpkg** — an overlay port ships under `ports/qbuem-json/`:
+
+```bash
+vcpkg install qbuem-json --overlay-ports=ports
+```
+
+Both expose the same target as CMake, so consuming code is identical:
+
+```cmake
+find_package(qbuem_json CONFIG REQUIRED)
 target_link_libraries(your_target PRIVATE qbuem_json::qbuem_json)
 ```
 

--- a/docs/guide/vision.md
+++ b/docs/guide/vision.md
@@ -41,7 +41,7 @@ The full, sourced roadmap lives in [`ROADMAP.md`](https://github.com/qbuem/qbuem
 - ⬜ **JSON Schema** (Draft-7 → 2020-12 subset) validation — OpenAPI / MCP alignment.
 - ⬜ **Schemaless On-Demand lazy cursor** — parse only the values you touch.
 - ⬜ **Chunked / incremental (socket) parsing** — resumable feeding from a partial buffer.
-- ⬜ **Packaging** — vcpkg + Conan registry; explicit JSONTestSuite conformance badge.
+- 🚧 **Packaging** — `find_package(qbuem_json CONFIG)` fixed, Conan recipe + vcpkg port shipped, CI-verified *(v1.11.1)*; registry submission (ConanCenter / vcpkg) is the remaining step.
 - ⬜ **C++26 P2996 reflection backend** — macro-free registration as an *opt-in fast-lane* once stable
   compilers ship (the macro stays the portable default).
 

--- a/include/qbuem_json/qbuem_json.hpp
+++ b/include/qbuem_json/qbuem_json.hpp
@@ -1,6 +1,12 @@
 /**
- * @brief qbuem-json v1.11.0 - High-Performance C++20 JSON Parser
- * @version 1.11.0
+ * @brief qbuem-json v1.11.1 - High-Performance C++20 JSON Parser
+ * @version 1.11.1
+ *
+ * v1.11.1: Packaging (roadmap Tier 3). Fixed the CMake install to generate and
+ *          install qbuem_jsonConfig.cmake, so `find_package(qbuem_json CONFIG)`
+ *          works downstream (previously only Targets + ConfigVersion shipped).
+ *          Added a Conan recipe (conanfile.py + test_package) and a vcpkg port.
+ *          Library code unchanged.
  *
  * v1.11.0: JSON diff + a complete functional RFC 6902 applier (roadmap Tier 3).
  *          qbuem::diff(from, to) computes the JSON Patch taking one document to

--- a/ports/qbuem-json/portfile.cmake
+++ b/ports/qbuem-json/portfile.cmake
@@ -1,0 +1,29 @@
+# Header-only library. Build the (tests/benchmarks-off) install tree, which now
+# ships qbuem_jsonConfig.cmake, then let vcpkg relocate it.
+#
+# NB: SHA512 is finalized when the matching release tag is published — replace
+# the placeholder below with the SHA512 of the v${VERSION} source tarball
+# (vcpkg will print the correct value on the first build attempt).
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO qbuem/qbuem-json
+    REF "v${VERSION}"
+    SHA512 0
+    HEAD_REF main
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DQBUEM_JSON_BUILD_TESTS=OFF
+        -DQBUEM_JSON_BUILD_BENCHMARKS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(PACKAGE_NAME qbuem_json CONFIG_PATH lib/cmake/qbuem_json)
+
+# Header-only: no libraries or debug tree to keep.
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib" "${CURRENT_PACKAGES_DIR}/debug")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/qbuem-json/vcpkg.json
+++ b/ports/qbuem-json/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "qbuem-json",
+  "version": "1.11.1",
+  "description": "Single-header C++20 JSON library: dual-engine SIMD DOM + zero-tape struct mapping, CBOR (RFC 8949), JSONPath (RFC 9535), canonicalization (RFC 8785), JSON diff/patch (RFC 6902). Zero dependencies.",
+  "homepage": "https://qbuem.com/qbuem-json/",
+  "license": "Apache-2.0",
+  "supports": "!windows",
+  "dependencies": [
+    { "name": "vcpkg-cmake", "host": true },
+    { "name": "vcpkg-cmake-config", "host": true }
+  ]
+}

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.15)
+project(test_package CXX)
+
+find_package(qbuem_json CONFIG REQUIRED)
+
+add_executable(example example.cpp)
+target_link_libraries(example PRIVATE qbuem_json::qbuem_json)
+target_compile_features(example PRIVATE cxx_std_20)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,24 @@
+import os
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeToolchain", "CMakeDeps"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindir, "example"), env="conanrun")

--- a/test_package/example.cpp
+++ b/test_package/example.cpp
@@ -1,0 +1,8 @@
+#include <qbuem_json/qbuem_json.hpp>
+#include <cstdio>
+
+int main() {
+    auto canon = qbuem::canonicalize(std::string_view(R"({"b":1,"a":2})"));
+    std::printf("canonicalize -> %s\n", canon.c_str());
+    return canon == "{\"a\":2,\"b\":1}" ? 0 : 1;
+}


### PR DESCRIPTION
**Roadmap Tier 3 (packaging).** Building the install tree surfaced a real bug: the CMake install exported `qbuem_jsonTargets.cmake` + `ConfigVersion.cmake` but **never generated `qbuem_jsonConfig.cmake`** — so `find_package(qbuem_json CONFIG)` failed downstream.

## Changes
- **Fix `find_package`:** add `cmake/qbuem_jsonConfig.cmake.in` + `configure_package_config_file`. Verified end-to-end — a fresh consumer does `find_package(qbuem_json CONFIG REQUIRED)` + links the target + builds + runs.
- **Conan:** `conanfile.py` (header-only recipe + `test_package`). **Verified locally** with `conan create` — `test_package` consumes via find_package and runs (`canonicalize -> {"a":2,"b":1}`).
- **vcpkg:** `ports/qbuem-json/` overlay port (`vcpkg.json` + `portfile.cmake`). SHA512 is a placeholder finalized at release (standard vcpkg flow).
- **CI:** new `packaging.yml` runs the CMake-install + find_package consumer check **and** a Conan create on every relevant change → the config can't regress.
- **Docs/README:** getting-started "Package managers" section; distribution badges.

Library code unchanged (**642/642**). Version **1.11.0 → 1.11.1** (the find_package fix is a packaging bugfix; recipes additive). Registry submission (ConanCenter / vcpkg) remains as the outward step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)