### PR TITLE
refactor: API hygiene — detail namespace, _to variants, jsonpath alias (v1.12.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,22 @@ fuzz/*.profraw
 fuzz/*.profdata
 fuzz/coverage_report/
 fuzz/corpus_fuzz_*/
+# Locally-grown libFuzzer corpus (SHA1-named entries). The curated named seeds
+# below stay tracked; new named seeds need `git add -f`.
+fuzz/corpus/*
+!fuzz/corpus/false
+!fuzz/corpus/float_val
+!fuzz/corpus/mixed
+!fuzz/corpus/ndjson-null-doc-regression
+!fuzz/corpus/nested_array
+!fuzz/corpus/nested_object
+!fuzz/corpus/null
+!fuzz/corpus/simple_array
+!fuzz/corpus/simple_object
+!fuzz/corpus/simple_string
+!fuzz/corpus/true
+!fuzz/corpus/unicode_string
+!fuzz/corpus/zero
 crash-*
 oom-*
 leak-*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(qbuem_json VERSION 1.11.2 LANGUAGES CXX)
+project(qbuem_json VERSION 1.12.0 LANGUAGES CXX)
 
 # Library Target
 add_library(qbuem_json INTERFACE)

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ from conan.tools.build import check_min_cppstd
 
 class QbuemJsonConan(ConanFile):
     name = "qbuem-json"
-    version = "1.11.1"
+    version = "1.12.0"
     license = "Apache-2.0"
     url = "https://github.com/qbuem/qbuem-json"
     homepage = "https://qbuem.com/qbuem-json/"

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -179,10 +179,10 @@ export default withMermaid(
                         applicationCategory: 'DeveloperApplication',
                         applicationSubCategory: 'C++ Library',
                         operatingSystem: 'Linux, macOS',
-                        version: '1.11.0',
-                        softwareVersion: '1.11.0',
-                        releaseNotes: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.11.0',
-                        downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.11.0',
+                        version: '1.12.0',
+                        softwareVersion: '1.12.0',
+                        releaseNotes: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.12.0',
+                        downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.12.0',
                         installUrl: 'https://qbuem.com/qbuem-json/guide/getting-started',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
                         keywords: 'C++ JSON library, C++20 JSON, fastest JSON parser, SIMD JSON, AVX-512 JSON, zero-allocation JSON, high-performance JSON, HFT JSON, JSON serializer, single header JSON, header-only JSON, CBOR C++, RFC 8949 CBOR, binary serialization C++, nlohmann alternative, simdjson alternative, RapidJSON alternative',
@@ -196,7 +196,7 @@ export default withMermaid(
                             'RFC 8259, RFC 6901, RFC 6902, RFC 8949, RFC 9535 (JSONPath) compliant',
                             'IEEE 754 round-trip float correctness',
                             'Rich parse errors: line/column/offset + caret rendering (format_error)',
-                            '642 passing tests, 16 libFuzzer targets',
+                            '649 passing tests, 16 libFuzzer targets',
                             'STL container support (vector, map, optional, tuple, variant)',
                             'Enum support: integer by default, value-name via QBUEM_JSON_ENUM (JSON + CBOR)',
                             'Field rename (member, "jsonKey") and skip-by-omission, across JSON/fuse/CBOR',
@@ -241,7 +241,7 @@ export default withMermaid(
                         },
                         runtimePlatform: 'C++20',
                         targetProduct: { '@id': 'https://qbuem.com/qbuem-json/#application' },
-                        version: '1.11.0',
+                        version: '1.12.0',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
                         keywords: 'C++, JSON, SIMD, AVX-512, High-Performance, HFT, parser, serializer, zero-allocation',
                         author: { '@id': 'https://qbuem.com/#organization' }
@@ -397,9 +397,9 @@ export default withMermaid(
                     ]
                 },
                 {
-                    text: 'v1.11.0',
+                    text: 'v1.12.0',
                     items: [
-                        { text: 'Release Notes', link: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.11.0' },
+                        { text: 'Release Notes', link: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.12.0' },
                         { text: 'All Releases', link: 'https://github.com/qbuem/qbuem-json/releases' }
                     ]
                 }

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -22,7 +22,7 @@ Minimum requirements: C++20, GCC 13+ or Clang 18+ or Apple Clang. Supported plat
 - [Custom Allocators](https://qbuem.com/qbuem-json/guide/allocators): Arena allocators, stack allocators, custom memory strategies
 - [Language Bindings](https://qbuem.com/qbuem-json/guide/bindings): C FFI, Python, Rust, Go, and WebAssembly (browser/Node) bindings
 - [Low-Latency Patterns](https://qbuem.com/qbuem-json/guide/low-latency-patterns): HFT tick data patterns, pre-allocated documents, reuse strategies
-- [Correctness & Safety](https://qbuem.com/qbuem-json/guide/correctness): RFC 8259/6901/6902/8949 compliance, IEEE 754 round-trip, rich parse errors (line/column/caret), enum support, field rename/skip, NDJSON streaming, canonical JSON, JSONPath query (RFC 9535), SAX event visitor, JSON diff + RFC 6902 apply_patch, 642 tests, sanitizers, fuzzing
+- [Correctness & Safety](https://qbuem.com/qbuem-json/guide/correctness): RFC 8259/6901/6902/8949 compliance, IEEE 754 round-trip, rich parse errors (line/column/caret), enum support, field rename/skip, NDJSON streaming, canonical JSON, JSONPath query (RFC 9535), SAX event visitor, JSON diff + RFC 6902 apply_patch, 649 tests, sanitizers, fuzzing
 - [Benchmarks](https://qbuem.com/qbuem-json/guide/benchmarks): Live CI benchmark results vs. simdjson, yyjson, RapidJSON, nlohmann
 - [Vision & Roadmap](https://qbuem.com/qbuem-json/guide/vision): Project goals and planned features
 

--- a/include/qbuem_json/qbuem_json.hpp
+++ b/include/qbuem_json/qbuem_json.hpp
@@ -1,6 +1,16 @@
 /**
- * @brief qbuem-json v1.11.2 - High-Performance C++20 JSON Parser
- * @version 1.11.2
+ * @brief qbuem-json v1.12.0 - High-Performance C++20 JSON Parser
+ * @version 1.12.0
+ *
+ * v1.12.0: API hygiene (no behavior change). (1) The internal helpers behind
+ *          canonicalize / diff / apply_patch / query (canon_emit_, value_equal,
+ *          the p6902_* / diff_* helpers, the JSONPath parser, ndjson_blank_) now
+ *          live in qbuem::json::detail instead of leaking into the public
+ *          qbuem:: namespace. (2) Added buffer-reuse overloads canonicalize_to,
+ *          diff_to (Value + string_view), and apply_patch_to that APPEND into a
+ *          caller-owned std::string; the string-returning forms now delegate to
+ *          them. (3) Added qbuem::jsonpath() as an alias for query() (the RFC 9535
+ *          spelling). Public API is otherwise unchanged and source-compatible.
  *
  * v1.11.2: Correctness fixes from a full review. (1) value_equal (diff / patch
  *          `test`) now compares integers exactly — a double compare wrongly
@@ -10493,6 +10503,7 @@ template <typename T>::std::string to_json_str(const T &val) {
 // For in-toolchain hashing/dedup this is fully deterministic; for cross-impl
 // RFC 8785 signing, account for the two notes above.
 
+namespace json::detail {
 inline void canon_emit_(const json::Value &v, ::std::string &out) {
   if (v.is_object()) {
     ::std::vector<::std::pair<::std::string, json::Value>> items;
@@ -10531,17 +10542,24 @@ inline void canon_emit_(const json::Value &v, ::std::string &out) {
     out += "null";
   }
 }
+} // namespace json::detail
 
 // Parse `json` and return its canonical form. Uses STRICT parsing (RFC 8259 +
 // well-formed UTF-8) — a canonical form is only meaningful for valid input, and
 // the signing/hashing use case must reject malformed data rather than silently
 // canonicalize a best-effort interpretation. Throws qbuem::parse_error otherwise.
-[[nodiscard]] inline ::std::string canonicalize(::std::string_view json) {
+// canonicalize_to(buf, json) — APPEND the canonical form of `json` to `buf`,
+// reusing its existing capacity (the caller owns the buffer). Same strict parsing
+// and output as canonicalize(); throws qbuem::parse_error on malformed input.
+inline void canonicalize_to(::std::string &buf, ::std::string_view json) {
   Document doc;
   Value root = parse_strict(doc, json);
+  buf.reserve(buf.size() + json.size());
+  json::detail::canon_emit_(root, buf);
+}
+[[nodiscard]] inline ::std::string canonicalize(::std::string_view json) {
   ::std::string out;
-  out.reserve(json.size());
-  canon_emit_(root, out);
+  canonicalize_to(out, json);
   return out;
 }
 
@@ -10572,6 +10590,9 @@ struct sax_handler {
 };
 
 // Walk `v`, dispatching events to `h`.  Returns false iff a handler aborted.
+// Recursion depth is bounded: `v` comes from the tape parser, which rejects input
+// nested deeper than kMaxDepth (1024), so this walk cannot overflow the stack on
+// adversarial input — the depth cap is enforced at parse time, not here.
 template <typename H>
 bool visit(const Value &v, H &h) {
   if (v.is_object()) {
@@ -10620,6 +10641,8 @@ bool sax_parse(::std::string_view json, H &h) {
 // is purely functional — each op parses the current document and rebuilds it with
 // the edit applied, so multi-op patches, array-index removal, pointer-token
 // unescaping, and whole-document replacement all behave correctly.
+
+namespace json::detail {
 
 inline bool value_equal(const Value &a, const Value &b); // defined below (diff)
 
@@ -10789,7 +10812,7 @@ p6902_apply_one_(::std::string_view doc_json, const Value &op_obj) {
   const ::std::string path = op_obj["path"] | "";
   if (op.empty() || (!path.empty() && path[0] != '/')) return ::std::nullopt;
   Document doc;
-  Value root = parse(doc, doc_json);
+  Value root = ::qbuem::parse(doc, doc_json);
   const auto toks = p6902_tokens_(path);
   if (op == "add" || op == "replace") {
     Value val = op_obj["value"];
@@ -10808,7 +10831,7 @@ p6902_apply_one_(::std::string_view doc_json, const Value &op_obj) {
       auto removed = p6902_edit_(root, p6902_tokens_(from), 0, 1, "");
       if (!removed) return ::std::nullopt;
       Document d2;
-      Value r2 = parse(d2, *removed);
+      Value r2 = ::qbuem::parse(d2, *removed);
       return p6902_edit_(r2, toks, 0, 0, *src);
     }
     return p6902_edit_(root, toks, 0, 0, *src);
@@ -10818,30 +10841,47 @@ p6902_apply_one_(::std::string_view doc_json, const Value &op_obj) {
     auto cur = p6902_value_at_(root, path);
     if (!cur || !val.is_valid()) return ::std::nullopt;
     Document da, db;
-    Value a = parse(da, *cur);
+    Value a = ::qbuem::parse(da, *cur);
     if (!value_equal(a, val)) return ::std::nullopt;
     return ::std::string(doc_json); // test passes — document unchanged
   }
   return ::std::nullopt; // unknown op
 }
+} // namespace json::detail
 
-// Apply a whole RFC 6902 patch to `doc_json`. Returns the patched document.
-// Throws qbuem::parse_error on malformed JSON; throws std::runtime_error if any
-// op fails (per RFC 6902, a patch is all-or-nothing).
-[[nodiscard]] inline ::std::string apply_patch(::std::string_view doc_json,
-                                               ::std::string_view patch_json) {
+// Apply a whole RFC 6902 patch to `doc_json`. Throws qbuem::parse_error on
+// malformed JSON; throws std::runtime_error if any op fails (per RFC 6902, a
+// patch is all-or-nothing).
+//
+// Complexity: O(ops × docsize) — the functional applier reparses and rebuilds
+// the whole document once per op, so a P-op patch over an N-byte document is
+// O(P·N). This trades speed for correctness (multi-op patches, array-index
+// removal, and pointer unescaping all round-trip); for a one-shot edit of a huge
+// document, prefer the in-place Value::patch().
+//
+// apply_patch_to(buf, doc, patch) APPENDS the patched document to `buf` (the
+// caller owns the buffer); apply_patch() is the convenience that returns a fresh
+// string.
+inline void apply_patch_to(::std::string &buf, ::std::string_view doc_json,
+                           ::std::string_view patch_json) {
   Document pdoc;
   Value patch = parse(pdoc, patch_json);
   if (!patch.is_array())
     throw ::std::runtime_error("apply_patch: patch must be a JSON array");
   ::std::string cur(doc_json);
   for (const Value &op : patch.elements()) {
-    auto next = p6902_apply_one_(cur, op);
+    auto next = json::detail::p6902_apply_one_(cur, op);
     if (!next)
       throw ::std::runtime_error("apply_patch: operation failed (bad path or op)");
     cur = ::std::move(*next); // settle: the next op sees this op's effect
   }
-  return cur;
+  buf += cur;
+}
+[[nodiscard]] inline ::std::string apply_patch(::std::string_view doc_json,
+                                               ::std::string_view patch_json) {
+  ::std::string out;
+  apply_patch_to(out, doc_json, patch_json);
+  return out;
 }
 
 // ── JSON diff (RFC 6902 patch generation) ────────────────────────────────────
@@ -10855,6 +10895,7 @@ p6902_apply_one_(::std::string_view doc_json, const Value &op_obj) {
 // a raw byte match (the common case — both docs escape keys the same way); the
 // slow path compares decoded keys so two spellings of the same key (e.g. "a" vs
 // "a") are treated as equal.
+namespace json::detail {
 inline ::std::optional<Value> find_by_decoded_key_(const Value &obj,
                                                    ::std::string_view raw_key) {
   if (auto m = obj.find(raw_key)) return m;
@@ -10959,23 +11000,37 @@ inline void diff_emit_(const Value &from, const Value &to,
     diff_op_value_(out, first, "replace", path, to);
   }
 }
+} // namespace json::detail
 
-// Returns an RFC 6902 patch (JSON array string) taking parsed `from` to `to`.
-[[nodiscard]] inline ::std::string diff(const Value &from, const Value &to) {
-  ::std::string out = "[";
+// diff_to(buf, from, to) — APPEND the RFC 6902 patch (a JSON array) taking
+// parsed `from` to `to` onto `buf`, reusing its capacity (the caller owns the
+// buffer). diff() is the convenience that returns a fresh string.
+inline void diff_to(::std::string &buf, const Value &from, const Value &to) {
+  buf += '[';
   bool first = true;
-  diff_emit_(from, to, ::std::string(), out, first);
-  out += ']';
-  return out;
+  json::detail::diff_emit_(from, to, ::std::string(), buf, first);
+  buf += ']';
 }
-
-// Parse both JSON strings and diff them. Throws on invalid input.
-[[nodiscard]] inline ::std::string diff(::std::string_view from_json,
-                                        ::std::string_view to_json) {
+// Parse both JSON strings, then diff them onto `buf`. Throws on invalid input.
+inline void diff_to(::std::string &buf, ::std::string_view from_json,
+                    ::std::string_view to_json) {
   Document fdoc, tdoc;
   Value f = parse(fdoc, from_json);
   Value t = parse(tdoc, to_json);
-  return diff(f, t);
+  diff_to(buf, f, t);
+}
+// Returns an RFC 6902 patch (JSON array string) taking parsed `from` to `to`.
+[[nodiscard]] inline ::std::string diff(const Value &from, const Value &to) {
+  ::std::string out;
+  diff_to(out, from, to);
+  return out;
+}
+// Parse both JSON strings and diff them. Throws on invalid input.
+[[nodiscard]] inline ::std::string diff(::std::string_view from_json,
+                                        ::std::string_view to_json) {
+  ::std::string out;
+  diff_to(out, from_json, to_json);
+  return out;
 }
 
 // ── JSONPath (RFC 9535 — structural selectors) ───────────────────────────────
@@ -10989,7 +11044,7 @@ inline void diff_emit_(const Value &from, const Value &to,
 // A syntactically malformed query throws qbuem::parse_error; a valid query that
 // matches nothing returns an empty vector.  Returned Values view into the same
 // document as `root`, so that document must outlive them.
-namespace jsonpath_detail {
+namespace json::detail::jsonpath {
 
 struct JpSelector {
   enum class Kind { Name, Wildcard, Index, Slice };
@@ -11160,6 +11215,9 @@ struct JpParser {
   }
 };
 
+// Recursion is bounded by the parser's kMaxDepth (1024) — `v` views a parsed
+// tape, which cannot be nested deeper than the parser allowed, so `$..` over
+// adversarial input can't overflow the stack.
 inline void jp_collect_descendants(const Value &v, ::std::vector<Value> &out) {
   out.push_back(v);
   if (v.is_object()) {
@@ -11205,11 +11263,11 @@ inline void jp_apply_selector(const Value &v, const JpSelector &s,
   }
 }
 
-} // namespace jsonpath_detail
+} // namespace json::detail::jsonpath
 
 [[nodiscard]] inline ::std::vector<Value> query(const Value &root,
                                                 ::std::string_view path) {
-  using namespace jsonpath_detail;
+  using namespace json::detail::jsonpath;
   JpParser parser{path.data(), path.data(), path.data() + path.size()};
   const ::std::vector<JpSegment> segs = parser.parse();
   ::std::vector<Value> nodes;
@@ -11231,6 +11289,16 @@ inline void jp_apply_selector(const Value &v, const JpSelector &s,
   return nodes;
 }
 
+// jsonpath(root, path) — the RFC 9535 spelling, an exact alias for query(root,
+// path). Returns every Value the path selects, in document order; the Values view
+// into the same document as `root`, which must outlive them. (There is no
+// string-input overload: it would parse into a temporary Document and return
+// dangling views — parse the text yourself, then call jsonpath/query.)
+[[nodiscard]] inline ::std::vector<Value> jsonpath(const Value &root,
+                                                   ::std::string_view path) {
+  return query(root, path);
+}
+
 // ── NDJSON / JSON Lines ──────────────────────────────────────────────────────
 // Newline-delimited JSON: one JSON value per line (jsonlines.org / ndjson-spec).
 // The dominant format for logs, ML datasets, and streamed LLM output. Records
@@ -11240,11 +11308,13 @@ inline void jp_apply_selector(const Value &v, const JpSelector &s,
 // relative to that record.
 
 // True for a line that is empty or only ASCII whitespace.
+namespace json::detail {
 inline bool ndjson_blank_(::std::string_view s) noexcept {
   for (char c : s)
     if (static_cast<unsigned char>(c) > ' ') return false;
   return true;
 }
+} // namespace json::detail
 
 // read_lines<T>(text, fn) — invoke fn(T&&) for each record, in order. fn may be
 // any callable taking a T by value/rvalue. Bounded memory: one Document and one
@@ -11259,7 +11329,7 @@ void read_lines(::std::string_view text, F &&fn) {
     ::std::size_t stop = (nl == ::std::string_view::npos) ? n : nl;
     ::std::string_view line = text.substr(pos, stop - pos);
     if (!line.empty() && line.back() == '\r') line.remove_suffix(1);
-    if (!ndjson_blank_(line)) {
+    if (!json::detail::ndjson_blank_(line)) {
       Value root = json::parse_reuse(doc, line);
       T obj{};
       json::detail::from_json(root, obj);

--- a/ports/qbuem-json/vcpkg.json
+++ b/ports/qbuem-json/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "qbuem-json",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Single-header C++20 JSON library: dual-engine SIMD DOM + zero-tape struct mapping, CBOR (RFC 8949), JSONPath (RFC 9535), canonicalization (RFC 8785), JSON diff/patch (RFC 6902). Zero dependencies.",
   "homepage": "https://qbuem.com/qbuem-json/",
   "license": "Apache-2.0",

--- a/tests/test_canonical.cpp
+++ b/tests/test_canonical.cpp
@@ -50,3 +50,15 @@ TEST(Canonical, ArraysPreserveOrderAndScalarsRoundTrip) {
 TEST(Canonical, InvalidInputThrows) {
   EXPECT_THROW((void)qbuem::canonicalize("{\"a\":}"), qbuem::parse_error);
 }
+
+TEST(Canonical, ToVariantAppendsToBuffer) {
+  // canonicalize_to APPENDS to the caller's buffer (reuses its content), and
+  // produces the same bytes the string-returning overload would.
+  std::string buf = "PREFIX:";
+  qbuem::canonicalize_to(buf, "{ \"b\":1, \"a\":2 }");
+  EXPECT_EQ(buf, "PREFIX:{\"a\":2,\"b\":1}");
+
+  std::string fresh;
+  qbuem::canonicalize_to(fresh, "{\"x\":1.50}");
+  EXPECT_EQ(fresh, qbuem::canonicalize("{\"x\":1.50}"));
+}

--- a/tests/test_diff.cpp
+++ b/tests/test_diff.cpp
@@ -119,3 +119,30 @@ TEST(ApplyPatch, FailedOpThrows) {
                                         std::string_view("not-an-array")),
                qbuem::parse_error);
 }
+
+TEST(Diff, ToVariantAppendsAndMatchesStringForm) {
+  // string_view overload: appends the patch onto the caller's buffer.
+  std::string buf = "P:";
+  qbuem::diff_to(buf, std::string_view("{\"a\":1}"), std::string_view("{\"a\":2}"));
+  EXPECT_EQ(buf, "P:[{\"op\":\"replace\",\"path\":\"/a\",\"value\":2}]");
+
+  // Value overload over an already-parsed pair matches the string-returning form.
+  qbuem::Document fd, td;
+  qbuem::Value f = qbuem::parse(fd, "{\"a\":1,\"b\":2}");
+  qbuem::Value t = qbuem::parse(td, "{\"a\":1,\"c\":3}");
+  std::string vbuf;
+  qbuem::diff_to(vbuf, f, t);
+  EXPECT_EQ(vbuf, qbuem::diff(f, t));
+}
+
+TEST(ApplyPatch, ToVariantAppendsToBuffer) {
+  std::string buf = "<<";
+  qbuem::apply_patch_to(buf, std::string_view("{\"a\":1}"),
+                        std::string_view(R"([{"op":"add","path":"/b","value":2}])"));
+  EXPECT_EQ(buf, "<<{\"a\":1,\"b\":2}");
+  // Failure path still throws, even with a pre-filled buffer.
+  std::string b2 = "x";
+  EXPECT_THROW(qbuem::apply_patch_to(b2, std::string_view("{\"a\":1}"),
+                                     std::string_view(R"([{"op":"remove","path":"/nope"}])")),
+               std::runtime_error);
+}

--- a/tests/test_jsonpath.cpp
+++ b/tests/test_jsonpath.cpp
@@ -109,3 +109,14 @@ TEST_F(JsonPath, OutOfRangeIndexRejectedNotWrapped) {
   // A large-but-representable index simply doesn't match.
   EXPECT_TRUE(qbuem::query(root, "$.nums[1000000000]").empty());
 }
+
+TEST_F(JsonPath, JsonpathAliasMatchesQuery) {
+  // qbuem::jsonpath is an exact alias for qbuem::query (the RFC 9535 spelling).
+  auto a = qbuem::jsonpath(root, "$.store.book[*].author");
+  auto b = qbuem::query(root, "$.store.book[*].author");
+  ASSERT_EQ(a.size(), b.size());
+  ASSERT_EQ(a.size(), 3u);
+  for (size_t i = 0; i < a.size(); ++i)
+    EXPECT_EQ(a[i].as<std::string_view>(), b[i].as<std::string_view>());
+  EXPECT_THROW((void)qbuem::jsonpath(root, "store.x"), qbuem::parse_error);
+}


### PR DESCRIPTION
## Summary

**API hygiene for v1.12.0 — no behavior change.** Tightens the public surface
exposed by the Tier 2/3 features added this cycle and adds buffer-reuse
overloads for hot loops.

### What changed

1. **Namespace hygiene** — the internal helpers behind `canonicalize` / `diff` /
   `apply_patch` / `query` no longer leak into the public `qbuem::` namespace.
   `canon_emit_`, `value_equal`, the `p6902_*` / `diff_*` helpers, the JSONPath
   parser (`jsonpath_detail` → `json::detail::jsonpath`), and `ndjson_blank_`
   now live in `qbuem::json::detail`.

2. **Buffer-reuse overloads** — `canonicalize_to`, `diff_to` (Value +
   string_view), and `apply_patch_to` **append** into a caller-owned
   `std::string` so callers can reuse capacity across a loop. The
   string-returning forms now delegate to them.

3. **`qbuem::jsonpath()`** added as an alias for `query()` (the RFC 9535
   spelling).

4. **Recursion-depth safety comments** on `visit` / `$..` descent / apply — the
   tape parser's `kMaxDepth` (1024) bounds the walk, so adversarial nesting
   cannot overflow the stack.

Public API is otherwise unchanged and source-compatible.

### Verification

- `ctest` — **649/649 pass** (was 645; +4 covering the new `_to` variants in
  `test_canonical` / `test_diff` / `test_jsonpath`) on a clean Release build.
- ASan/UBSan clean on the affected suites; `fuzz_apply_patch` driver ran 8M
  iterations clean locally.
- Version bumped to **1.12.0** across CMake, Conan, vcpkg, and docs.
- `.gitignore` now ignores locally-grown libFuzzer corpus (the 13 named seeds
  stay tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
