### PR TITLE
test: JSONTestSuite conformance — 100% on 283 mandatory cases (Tier 3 #14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,3 +172,40 @@ jobs:
       run: |
         ctest -C ${{ matrix.build_type }} --output-on-failure --timeout 180 \
           || ctest -C ${{ matrix.build_type }} --output-on-failure --timeout 180 --rerun-failed
+
+  # ── JSONTestSuite conformance ─────────────────────────────────────────────
+  # Runs the canonical "Parsing JSON is a Minefield" corpus (nst/JSONTestSuite,
+  # pinned commit) through parse_strict, under ASan+UBSan so the 318 adversarial
+  # inputs also prove memory safety. The corpus is fetched here, not vendored;
+  # test_jsontestsuite skips when QBUEM_JSONTESTSUITE_DIR is unset (every other job).
+  conformance:
+    name: JSONTestSuite conformance (ASan+UBSan)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Install Clang 18
+      run: wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s 18
+
+    - name: Fetch JSONTestSuite corpus (pinned)
+      run: |
+        git clone --filter=blob:none --no-checkout https://github.com/nst/JSONTestSuite.git "$RUNNER_TEMP/JSONTestSuite"
+        git -C "$RUNNER_TEMP/JSONTestSuite" checkout 1ef36fa01286573e846ac449e8683f8833c5b26a
+        echo "QBUEM_JSONTESTSUITE_DIR=$RUNNER_TEMP/JSONTestSuite" >> "$GITHUB_ENV"
+
+    - name: Configure (ASan+UBSan)
+      env:
+        CC: clang-18
+        CXX: clang++-18
+      run: >
+        cmake -B build-conformance
+        -DCMAKE_BUILD_TYPE=Debug
+        -DQBUEM_JSON_BUILD_TESTS=ON
+        -DQBUEM_JSON_BUILD_BENCHMARKS=OFF
+        -DQBUEM_JSON_SANITIZE=ON
+
+    - name: Build conformance test
+      run: cmake --build build-conformance --target test_jsontestsuite -j2
+
+    - name: Run conformance (95 y_ accept · 188 n_ reject · 35 i_ profile)
+      run: ./build-conformance/tests/test_jsontestsuite --gtest_color=yes

--- a/README.md
+++ b/README.md
@@ -29,13 +29,14 @@
 
   <!-- Testing -->
   <p>
-    <a href="https://qbuem.com/qbuem-json/guide/correctness"><img src="https://img.shields.io/badge/tests-558%20passing-brightgreen" alt="558 tests passing"></a>
-    <a href="https://qbuem.com/qbuem-json/guide/correctness#fuzz-testing"><img src="https://img.shields.io/badge/fuzz-11%20libFuzzer%20targets-orange" alt="11 libFuzzer targets"></a>
+    <a href="https://qbuem.com/qbuem-json/guide/correctness"><img src="https://img.shields.io/badge/tests-649%20passing-brightgreen" alt="649 tests passing"></a>
+    <a href="https://qbuem.com/qbuem-json/guide/correctness#fuzz-testing"><img src="https://img.shields.io/badge/fuzz-16%20libFuzzer%20targets-orange" alt="16 libFuzzer targets"></a>
+    <a href="https://qbuem.com/qbuem-json/guide/correctness#jsontestsuite-conformance"><img src="https://img.shields.io/badge/JSONTestSuite-100%25%20(283%2F283)-brightgreen" alt="JSONTestSuite 100% (283/283 mandatory cases)"></a>
   </p>
 
   <!-- Distribution -->
   <p>
-    <a href="https://github.com/qbuem/qbuem-json/releases/tag/v1.0.8"><img src="https://img.shields.io/badge/version-v1.0.8-blue" alt="v1.0.8"></a>
+    <a href="https://github.com/qbuem/qbuem-json/releases/tag/v1.12.0"><img src="https://img.shields.io/badge/version-v1.12.0-blue" alt="v1.12.0"></a>
     <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="Apache 2.0"></a>
     <a href="https://github.com/qbuem/qbuem-json/blob/main/include/qbuem_json/qbuem_json.hpp"><img src="https://img.shields.io/badge/header--only-single%20file-lightgrey" alt="header-only"></a>
     <img src="https://img.shields.io/badge/dependencies-zero-brightgreen" alt="zero dependencies">

--- a/docs/guide/correctness.md
+++ b/docs/guide/correctness.md
@@ -54,7 +54,8 @@ reproduce locally.
 | AddressSanitizer (ASan) | ✅ CI | [sanitizers.yml](https://github.com/qbuem/qbuem-json/actions/workflows/sanitizers.yml) |
 | UndefinedBehaviorSanitizer (UBSan) | ✅ CI | [sanitizers.yml](https://github.com/qbuem/qbuem-json/actions/workflows/sanitizers.yml) |
 | ThreadSanitizer (TSan) | ✅ CI | [sanitizers.yml](https://github.com/qbuem/qbuem-json/actions/workflows/sanitizers.yml) |
-| Fuzz testing | ✅ | 11 libFuzzer targets · **64.02% branch coverage** |
+| Fuzz testing | ✅ | 16 libFuzzer targets · **64.02% branch coverage** |
+| JSONTestSuite conformance | ✅ CI | **283/283** mandatory cases (95 accept · 188 reject) under ASan+UBSan |
 | IEEE 754 round-trip | ✅ | All 64-bit doubles; parsing: `eisel_lemire_f64` (~98.8 %) → `russ_cox_uscale_f64` (~1.2 %) → `strtod` (subnormals); serialization: Schubfach / `qj_nc::f64_to_dec` |
 | CodeQL static analysis | ✅ CI weekly | security-extended query suite |
 | Multi-platform CI | ✅ [10 configs](https://github.com/qbuem/qbuem-json/blob/main/.github/workflows/ci.yml) | GCC 13/14 · Clang 18 · Apple Clang · x86_64 · aarch64 · Apple Silicon |
@@ -130,6 +131,59 @@ JSON and are accepted. Resolution is deterministic but engine-specific: the DOM
 (`operator[]`, `read<T>`) is **first-wins**; Nexus (`fuse<T>`) is **last-wins**
 (matching JavaScript / Python / Go). Reject or canonicalize upstream if duplicate
 keys are security-relevant.
+
+---
+
+## JSONTestSuite conformance
+
+Beyond the hand-written cases above, qbuem-json is run against the full
+[**JSONTestSuite**](https://github.com/nst/JSONTestSuite) corpus — Nicolas
+Seriot's *"Parsing JSON is a Minefield"* set, the de-facto adversarial benchmark
+every serious JSON parser is measured against (318 files probing number edges,
+UTF-8 traps, structural limits, and whitespace corner cases).
+
+The corpus splits cases by required behaviour, and `parse_strict()` is **100% on
+both mandatory categories**:
+
+| Category | Meaning | Result |
+|:---|:---|:---|
+| `y_` | **Must accept** — well-formed JSON | **95 / 95** ✅ |
+| `n_` | **Must reject** — malformed JSON | **188 / 188** ✅ |
+| `i_` | Implementation-defined — either outcome is RFC-legal | 35, profiled below |
+
+Passing all 188 `n_` cases is the load-bearing result: it means the strict
+parser never *accepts* invalid JSON, the dangerous direction when the input is
+untrusted. The run executes under **ASan + UBSan**, so the 318 adversarial
+inputs simultaneously prove memory safety.
+
+### Implementation-defined profile
+
+The 35 `i_` cases have no single correct answer, so we **freeze our documented
+choices** as a regression guard (`tests/test_jsontestsuite.cpp`) — a code change
+that flips any one of them fails CI and must be reviewed deliberately. The theme
+is coherent:
+
+| We **accept** (21) | We **reject** (14) |
+|:---|:---|
+| Numeric overflow / underflow → ±inf / 0 per IEEE 754 (`1e400`, huge exponents, oversized ints) | Every **malformed UTF-8/UTF-16 byte** sequence — invalid, overlong, truncated, lone continuation, ISO-Latin-1, UTF-16 without BOM |
+| Lone / inverted `\uXXXX` surrogate *escapes* (decoded to U+FFFD) | A leading UTF-8 BOM |
+| Nesting up to the parser's depth cap (`i_structure_500_nested_arrays`) | |
+
+In short: **strict on encoding-level validity, lenient on `\u`-escape surrogate
+pairing and numeric magnitude.**
+
+### Running it yourself
+
+The corpus is not vendored (it carries its own licence and would bloat the
+repo); `test_jsontestsuite` skips unless you point it at a checkout:
+
+```bash
+git clone https://github.com/nst/JSONTestSuite.git
+QBUEM_JSONTESTSUITE_DIR=$PWD/JSONTestSuite ctest --test-dir build -R JSONTestSuite
+```
+
+CI fetches it at a pinned commit and runs the suite on every push and pull
+request (the `conformance` job in [ci.yml](https://github.com/qbuem/qbuem-json/blob/main/.github/workflows/ci.yml)).
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,14 +69,15 @@ features:
   <!-- Row 3: Testing -->
   <div style="display: flex; align-items: center; gap: 0.4rem; flex-wrap: wrap; margin-bottom: 0.5rem;">
     <span style="font-size: 0.68rem; font-weight: 700; letter-spacing: 0.07em; text-transform: uppercase; color: #999; min-width: 5.5rem; flex-shrink: 0;">Testing</span>
-    <a href="/qbuem-json/guide/correctness"><img src="https://img.shields.io/badge/tests-521%20passing-brightgreen" alt="521 tests passing" /></a>
-    <a href="/qbuem-json/guide/correctness#fuzz-testing"><img src="https://img.shields.io/badge/fuzz-11%20libFuzzer%20targets-orange" alt="11 libFuzzer targets" /></a>
+    <a href="/qbuem-json/guide/correctness"><img src="https://img.shields.io/badge/tests-649%20passing-brightgreen" alt="649 tests passing" /></a>
+    <a href="/qbuem-json/guide/correctness#fuzz-testing"><img src="https://img.shields.io/badge/fuzz-16%20libFuzzer%20targets-orange" alt="16 libFuzzer targets" /></a>
+    <a href="/qbuem-json/guide/correctness#jsontestsuite-conformance"><img src="https://img.shields.io/badge/JSONTestSuite-100%25%20(283%2F283)-brightgreen" alt="JSONTestSuite 100% (283/283 mandatory cases)" /></a>
   </div>
 
   <!-- Row 4: Package -->
   <div style="display: flex; align-items: center; gap: 0.4rem; flex-wrap: wrap;">
     <span style="font-size: 0.68rem; font-weight: 700; letter-spacing: 0.07em; text-transform: uppercase; color: #999; min-width: 5.5rem; flex-shrink: 0;">Package</span>
-    <a href="https://github.com/qbuem/qbuem-json/releases/tag/v1.0.8"><img src="https://img.shields.io/badge/version-v1.0.8-blue" alt="v1.0.8" /></a>
+    <a href="https://github.com/qbuem/qbuem-json/releases/tag/v1.12.0"><img src="https://img.shields.io/badge/version-v1.12.0-blue" alt="v1.12.0" /></a>
     <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="Apache 2.0" /></a>
     <a href="https://github.com/qbuem/qbuem-json/blob/main/include/qbuem_json/qbuem_json.hpp"><img src="https://img.shields.io/badge/header--only-single%20file-lightgrey" alt="header-only" /></a>
     <img src="https://img.shields.io/badge/dependencies-zero-brightgreen" alt="zero dependencies" />

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -22,7 +22,7 @@ Minimum requirements: C++20, GCC 13+ or Clang 18+ or Apple Clang. Supported plat
 - [Custom Allocators](https://qbuem.com/qbuem-json/guide/allocators): Arena allocators, stack allocators, custom memory strategies
 - [Language Bindings](https://qbuem.com/qbuem-json/guide/bindings): C FFI, Python, Rust, Go, and WebAssembly (browser/Node) bindings
 - [Low-Latency Patterns](https://qbuem.com/qbuem-json/guide/low-latency-patterns): HFT tick data patterns, pre-allocated documents, reuse strategies
-- [Correctness & Safety](https://qbuem.com/qbuem-json/guide/correctness): RFC 8259/6901/6902/8949 compliance, IEEE 754 round-trip, rich parse errors (line/column/caret), enum support, field rename/skip, NDJSON streaming, canonical JSON, JSONPath query (RFC 9535), SAX event visitor, JSON diff + RFC 6902 apply_patch, 649 tests, sanitizers, fuzzing
+- [Correctness & Safety](https://qbuem.com/qbuem-json/guide/correctness): RFC 8259/6901/6902/8949 compliance, IEEE 754 round-trip, rich parse errors (line/column/caret), enum support, field rename/skip, NDJSON streaming, canonical JSON, JSONPath query (RFC 9535), SAX event visitor, JSON diff + RFC 6902 apply_patch, 100% JSONTestSuite conformance (283/283 mandatory cases under ASan+UBSan), 649 tests, sanitizers, fuzzing
 - [Benchmarks](https://qbuem.com/qbuem-json/guide/benchmarks): Live CI benchmark results vs. simdjson, yyjson, RapidJSON, nlohmann
 - [Vision & Roadmap](https://qbuem.com/qbuem-json/guide/vision): Project goals and planned features
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,9 @@ add_qbuem_gtest(test_canonical)
 add_qbuem_gtest(test_jsonpath)
 add_qbuem_gtest(test_sax)
 add_qbuem_gtest(test_diff)
+# JSONTestSuite conformance — skips unless QBUEM_JSONTESTSUITE_DIR points at a
+# checkout of the corpus (CI clones it at a pinned commit; see conformance job).
+add_qbuem_gtest(test_jsontestsuite)
 
 # ── New: dom API type coverage and round-trip fidelity ────────────────────
 add_qbuem_gtest(test_dom_types)

--- a/tests/test_jsontestsuite.cpp
+++ b/tests/test_jsontestsuite.cpp
@@ -1,0 +1,191 @@
+// test_jsontestsuite.cpp — conformance against the canonical JSONTestSuite corpus
+// ("Parsing JSON is a Minefield", nst/JSONTestSuite), the de-facto adversarial
+// test set for JSON parsers.
+//
+// The corpus is NOT vendored (it would bloat the repo and carries its own
+// licence); CI clones it at a pinned commit and points us at it via the
+// QBUEM_JSONTESTSUITE_DIR environment variable. When that variable is unset
+// (the normal local/matrix build), every test here GTEST_SKIPs — so this file
+// is a no-op unless the corpus is present.
+//
+// Naming convention (JSONTestSuite):
+//   y_ → MUST be accepted (well-formed JSON)            → we assert parse_strict OK
+//   n_ → MUST be rejected (malformed JSON)              → we assert parse_strict throws
+//   i_ → implementation-defined (either is RFC-legal)   → we freeze our documented
+//        profile below so a behavioural drift is caught and consciously reviewed.
+//
+// We test against parse_strict() (RFC 8259 + well-formed UTF-8), the mode whose
+// whole contract is "reject anything not strictly valid".
+
+#include <qbuem_json/qbuem_json.hpp>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace {
+namespace fs = std::filesystem;
+
+// Path to the JSONTestSuite checkout's `test_parsing` directory, or empty if the
+// corpus is not available (then every test skips).
+fs::path corpus_dir() {
+  const char *root = std::getenv("QBUEM_JSONTESTSUITE_DIR");
+  if (!root || !*root) return {};
+  fs::path tp = fs::path(root) / "test_parsing";
+  std::error_code ec;
+  if (!fs::is_directory(tp, ec)) return {};
+  return tp;
+}
+
+std::string read_file(const fs::path &p) {
+  std::ifstream f(p, std::ios::binary);
+  std::ostringstream ss;
+  ss << f.rdbuf();
+  return ss.str();
+}
+
+// True iff parse_strict accepts `bytes`. Any thrown type counts as a rejection —
+// a conformant parser may signal malformed input however it likes.
+bool strict_accepts(const std::string &bytes) {
+  try {
+    qbuem::Document doc;
+    qbuem::parse_strict(doc, bytes);
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+std::vector<fs::path> cases_with_prefix(const fs::path &dir, std::string_view prefix) {
+  std::vector<fs::path> out;
+  for (const auto &e : fs::directory_iterator(dir)) {
+    if (e.path().extension() != ".json") continue;
+    if (e.path().filename().string().rfind(std::string(prefix), 0) == 0)
+      out.push_back(e.path());
+  }
+  std::sort(out.begin(), out.end());
+  return out;
+}
+
+// ── Frozen implementation-defined profile (JSONTestSuite, pinned commit) ──────
+// Our documented choices on the RFC-implementation-defined i_ cases. Coherent
+// theme: we are STRICT on UTF-8/UTF-16 byte validity (reject every malformed
+// encoding) but LENIENT on \u-escape surrogate pairing and numeric overflow
+// (huge magnitudes clamp to ±inf / 0 per IEEE 754), and we accept nesting up to
+// the parser's depth cap (1024). If a code change flips one of these, the
+// matching test fails on purpose — update the docs and this list deliberately.
+const std::set<std::string> kImplDefinedAccept = {
+    "i_number_double_huge_neg_exp.json",
+    "i_number_huge_exp.json",
+    "i_number_neg_int_huge_exp.json",
+    "i_number_pos_double_huge_exp.json",
+    "i_number_real_neg_overflow.json",
+    "i_number_real_pos_overflow.json",
+    "i_number_real_underflow.json",
+    "i_number_too_big_neg_int.json",
+    "i_number_too_big_pos_int.json",
+    "i_number_very_big_negative_int.json",
+    "i_object_key_lone_2nd_surrogate.json",
+    "i_string_1st_surrogate_but_2nd_missing.json",
+    "i_string_1st_valid_surrogate_2nd_invalid.json",
+    "i_string_incomplete_surrogate_and_escape_valid.json",
+    "i_string_incomplete_surrogate_pair.json",
+    "i_string_incomplete_surrogates_escape_valid.json",
+    "i_string_invalid_lonely_surrogate.json",
+    "i_string_invalid_surrogate.json",
+    "i_string_inverted_surrogates_U+1D11E.json",
+    "i_string_lone_second_surrogate.json",
+    "i_structure_500_nested_arrays.json",
+};
+const std::set<std::string> kImplDefinedReject = {
+    "i_string_UTF-16LE_with_BOM.json",
+    "i_string_UTF-8_invalid_sequence.json",
+    "i_string_UTF8_surrogate_U+D800.json",
+    "i_string_invalid_utf-8.json",
+    "i_string_iso_latin_1.json",
+    "i_string_lone_utf8_continuation_byte.json",
+    "i_string_not_in_unicode_range.json",
+    "i_string_overlong_sequence_2_bytes.json",
+    "i_string_overlong_sequence_6_bytes.json",
+    "i_string_overlong_sequence_6_bytes_null.json",
+    "i_string_truncated-utf-8.json",
+    "i_string_utf16BE_no_BOM.json",
+    "i_string_utf16LE_no_BOM.json",
+    "i_structure_UTF-8_BOM_empty_object.json",
+};
+} // namespace
+
+// y_ : every well-formed document must be accepted. A failure here means we
+// wrongly REJECT valid JSON — a hard conformance bug.
+TEST(JSONTestSuite, MustAcceptAllValid) {
+  fs::path dir = corpus_dir();
+  if (dir.empty()) GTEST_SKIP() << "QBUEM_JSONTESTSUITE_DIR not set";
+  const auto files = cases_with_prefix(dir, "y_");
+  ASSERT_FALSE(files.empty()) << "no y_ cases found in " << dir;
+  std::vector<std::string> wrongly_rejected;
+  for (const auto &p : files)
+    if (!strict_accepts(read_file(p)))
+      wrongly_rejected.push_back(p.filename().string());
+  EXPECT_TRUE(wrongly_rejected.empty())
+      << wrongly_rejected.size() << " valid documents wrongly rejected:\n  "
+      << [&] {
+           std::string s;
+           for (const auto &n : wrongly_rejected) s += n + "\n  ";
+           return s;
+         }();
+}
+
+// n_ : every malformed document must be rejected. A failure here means we
+// wrongly ACCEPT invalid JSON — the dangerous direction for untrusted input.
+TEST(JSONTestSuite, MustRejectAllInvalid) {
+  fs::path dir = corpus_dir();
+  if (dir.empty()) GTEST_SKIP() << "QBUEM_JSONTESTSUITE_DIR not set";
+  const auto files = cases_with_prefix(dir, "n_");
+  ASSERT_FALSE(files.empty()) << "no n_ cases found in " << dir;
+  std::vector<std::string> wrongly_accepted;
+  for (const auto &p : files)
+    if (strict_accepts(read_file(p)))
+      wrongly_accepted.push_back(p.filename().string());
+  EXPECT_TRUE(wrongly_accepted.empty())
+      << wrongly_accepted.size() << " invalid documents wrongly accepted:\n  "
+      << [&] {
+           std::string s;
+           for (const auto &n : wrongly_accepted) s += n + "\n  ";
+           return s;
+         }();
+}
+
+// i_ : implementation-defined. Either outcome is RFC-legal, so we don't judge
+// right/wrong — we lock our documented profile so a silent behavioural drift is
+// surfaced for deliberate review, and force any brand-new i_ case to be
+// classified rather than silently ignored.
+TEST(JSONTestSuite, ImplementationDefinedProfileIsStable) {
+  fs::path dir = corpus_dir();
+  if (dir.empty()) GTEST_SKIP() << "QBUEM_JSONTESTSUITE_DIR not set";
+  const auto files = cases_with_prefix(dir, "i_");
+  ASSERT_FALSE(files.empty()) << "no i_ cases found in " << dir;
+  for (const auto &p : files) {
+    const std::string name = p.filename().string();
+    const bool accepted = strict_accepts(read_file(p));
+    const bool known_accept = kImplDefinedAccept.count(name) != 0;
+    const bool known_reject = kImplDefinedReject.count(name) != 0;
+    ASSERT_TRUE(known_accept || known_reject)
+        << "unclassified new i_ case '" << name
+        << "' — decide our behaviour and add it to the frozen profile in "
+           "test_jsontestsuite.cpp + docs";
+    if (known_accept)
+      EXPECT_TRUE(accepted) << name << " flipped to REJECTED — implementation-"
+                               "defined profile changed; update docs + list deliberately";
+    else
+      EXPECT_FALSE(accepted) << name << " flipped to ACCEPTED — implementation-"
+                                "defined profile changed; update docs + list deliberately";
+  }
+}


### PR DESCRIPTION
## Summary

**Roadmap Tier 3 #14 (last mile): JSONTestSuite conformance.** Runs the canonical
[*"Parsing JSON is a Minefield"*](https://github.com/nst/JSONTestSuite) corpus —
the de-facto adversarial benchmark every serious JSON parser is measured
against — through `parse_strict`.

### Result: 100% on the mandatory categories

| Category | Meaning | Result |
|:---|:---|:---|
| `y_` | must accept (valid) | **95 / 95** ✅ |
| `n_` | must reject (invalid) | **188 / 188** ✅ |
| `i_` | implementation-defined | 35, profiled & frozen |

**No parser fixes were needed** — passing all 188 `n_` cases means the strict
parser never *accepts* invalid JSON (the dangerous direction for untrusted
input).

### What's in the PR

- **`tests/test_jsontestsuite.cpp`** — env-var driven (`QBUEM_JSONTESTSUITE_DIR`);
  **skips when the corpus is absent**, so the normal 20-job matrix is unaffected.
  Hard-asserts all `y_` accept + all `n_` reject, and **freezes the 35 `i_`
  outcomes** as a regression guard that also forces any brand-new `i_` case to be
  classified rather than silently ignored.
- **`conformance` CI job** (`ci.yml`) — clones the corpus at a **pinned commit**
  and runs the suite under **ASan + UBSan**, so the 318 adversarial inputs
  simultaneously prove memory safety.
- **Docs** — new "JSONTestSuite conformance" section in the correctness guide +
  a `100% (283/283)` badge; corrected stale **tests (→649) / fuzz (→16) /
  version (→v1.12.0)** badges in the README and docs landing page.

Our implementation-defined profile is coherent: **strict on UTF-8/UTF-16 byte
validity** (reject all 14 malformed encodings), **lenient on `\u`-escape
surrogate pairing and numeric overflow** (accept 21). The corpus is fetched, not
vendored (its own licence; avoids repo bloat).

### Verification (local)

- `ctest` — **652 total, 0 failed**; the 3 conformance tests pass with the
  corpus present and skip cleanly without it.
- Also green under **ASan + UBSan** against the full corpus locally.
- `vitepress build` exits 0; edited pages render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
