### PR TITLE
docs: decline JSON Schema (#10), document validator interop; roadmap complete

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,14 +55,33 @@ differentiators where few competitors play.
 
 ## Tier 3 — Longer-term / heavier
 
-| # | Feature | Why | Effort |
-|---|---------|-----|--------|
-| 10 | **JSON Schema (Draft-7 → 2020-12 subset)** validation | Strongest *external* demand (OpenAPI 3.1/3.2, MCP default dialect) but heaviest; ship a subset or document blaze/jsoncons interop. | **L–XL** |
-| 11 | **Structural diff / patch generation** (compute a minimal 6902 patch between two docs) | Natural extension of our existing 6902; powers real-time **game state sync** (our use case). | **M–L** |
-| 12 | **Schemaless On-Demand lazy cursor** (parse only what you touch) | simdjson's headline model; our `fuse` already covers the *known-schema* case, this is the schemaless gap. Subtle iterator-invalidation semantics. | **L** |
-| 13 | **Chunked / incremental (socket) parsing** — resumable `write_some`-style feeding | Parse straight off a socket without full buffering; pairs with framed CBOR. | **M** |
-| 14 | **Packaging**: vcpkg + Conan registry entries; explicit **JSONTestSuite** conformance badge | Adoption + credibility; we are single-header + fuzzed already, this is the last mile. | **S** |
-| 15 | **C++26 P2996 reflection backend** (opt-in, `#ifdef __cpp_reflection`) | Macro-free registration as an *additive fast-lane* (Glaze's dual-mode). **Not** a baseline — no stable compiler until ~2028; keep the macro as the portable default. | **L** |
+| # | Feature | Why | Effort | Status |
+|---|---------|-----|--------|--------|
+| 10 | ~~**JSON Schema (Draft-7 → 2020-12 subset)** validation~~ | Strongest *external* demand (OpenAPI 3.1/3.2, MCP default dialect) but heaviest. | **L–XL** | ❌ **DECLINED** (2026-06-21) — see below |
+| 11 | ✅ **Structural diff / patch generation** *(v1.11.0, `qbuem::diff` + functional RFC 6902 `apply_patch`)* | Natural extension of our existing 6902; powers real-time **game state sync** (our use case). | **M–L** | done |
+| 12 | ❌ **Schemaless On-Demand lazy cursor** — **DECLINED** | simdjson parity-chase; our flat-tape DOM + `fuse` already cover the known-schema case, and the iterator-invalidation semantics are a high regression-risk surface for a benefit our use case doesn't need. | — | declined |
+| 13 | ⏸️ **Chunked / incremental (socket) parsing** — **DEFERRED** | WebSocket frames and framed CBOR are already message-delimited, so a whole message arrives before parse — the incremental need is largely already met. Revisit only if a real streaming workload appears. | **M** | deferred |
+| 14 | ✅ **Packaging** *(v1.11.1 vcpkg + Conan)* + **JSONTestSuite conformance** *(283/283 mandatory, ASan+UBSan CI)* | Adoption + credibility; we are single-header + fuzzed already, this was the last mile. | **S** | done |
+| 15 | ⏸️ **C++26 P2996 reflection backend** (opt-in, `#ifdef __cpp_reflection`) — **GATED** | Macro-free registration as an *additive fast-lane* (Glaze's dual-mode). **Not** a baseline — no stable compiler until ~2028; keep the macro as the portable default. | **L** | gated to ~2028 |
+
+### #10 JSON Schema — DECLINED (build) / document interop instead
+
+Validating against an external JSON Schema is a runtime concern, and three things
+make shipping our own validator a poor fit:
+
+1. **Not differentiated** — jsoncons (`jsonschema`), blaze, and valijson already
+   do this well. A partial Draft-2020-12 subset would *copy for parity* (rule #2)
+   while inviting "looks like Schema but isn't" frustration.
+2. **Over-engineering risk** — even a subset is L–XL (`$ref` resolution,
+   recursive schemas, format/pattern validators) and would noticeably bloat the
+   single header (rule #3).
+3. **Our use case doesn't need it** — for known C++ shapes, `fuse<T>` /
+   `QBUEM_JSON_FIELDS` give *compile-time* structural validation: a missing or
+   mistyped field is already a parse error, stronger than a runtime schema check.
+
+→ Instead we **document interop**: validate dynamic/untrusted JSON at the trust
+boundary with a dedicated library, then parse with qbuem-json for speed. See the
+[Correctness guide → Schema validation](https://qbuem.com/qbuem-json/guide/correctness#json-schema-validation-interop).
 
 ## Defer / Decline (low ROI or speculative)
 
@@ -80,8 +99,18 @@ differentiators where few competitors play.
   cross-language) where we already lead.
 - **Tier 2 = "feature parity + reach."** JSONPath + SAX close the last big functional gaps;
   WASM + MessagePack + runtime dispatch extend reach without diluting the core.
-- **Tier 3 = "depth bets."** Schema and the On-Demand cursor are large; take them on once the
-  Tier 1/2 base is broad. P2996 is the future, gated and additive — never the baseline.
+- **Tier 3 = "depth bets."** Shipped the two that fit our identity (structural diff/patch +
+  packaging/conformance). Declined the rest after curation: JSON Schema (not differentiated,
+  over-engineering risk — document interop instead), the On-Demand lazy cursor (simdjson
+  parity-chase), and incremental socket parsing (deferred — framing already covers it). P2996
+  is the future, gated and additive — never the baseline.
+
+## Status (2026-06-21): curated roadmap complete
+
+Tier 1 + Tier 2 + the curated subset of Tier 3 are shipped through **v1.13.0**. Every remaining
+candidate is consciously **declined / deferred / gated** above (not forgotten). The library is
+feature-complete for its identity — *fastest + safest single-header C++20 JSON, dual-engine, with
+a cross-language binary (CBOR) story*. Further work is demand-driven, not roadmap-driven.
 
 ### Sources
 RFC 9535 JSONPath (Feb 2024) · RFC 8785 JCS · RFC 8949 §4.2 deterministic CBOR · JSON Schema

--- a/docs/guide/correctness.md
+++ b/docs/guide/correctness.md
@@ -187,6 +187,47 @@ request (the `conformance` job in [ci.yml](https://github.com/qbuem/qbuem-json/b
 
 ---
 
+## JSON Schema validation (interop)
+
+qbuem-json **does not ship a JSON Schema validator**, and that is a deliberate
+scope decision, not a gap:
+
+- **For known C++ shapes, you don't need one.** `QBUEM_JSON_FIELDS` + `read<T>()`
+  / `fuse<T>` give you *compile-time* structural validation: a missing or
+  mistyped field is already a typed parse error. That is stronger and faster than
+  a runtime schema check, with zero schema document to maintain.
+
+  ```cpp
+  struct CreateUser { std::string name; int age; };
+  QBUEM_JSON_FIELDS(CreateUser, name, age)
+
+  auto r = qbuem::read<CreateUser>(body);   // wrong type / missing field → r is an error
+  if (!r) return reject(r.error());          // no JSON Schema needed
+  ```
+
+- **For dynamic JSON against an *external* schema** (OpenAPI 3.1, the MCP default
+  dialect, etc.), validate at the trust boundary with a dedicated, fully
+  Draft-2020-12-compliant library — [jsoncons
+  `jsonschema`](https://github.com/danielaparker/jsoncons),
+  [blaze](https://github.com/sourcemeta/blaze), or
+  [valijson](https://github.com/tristanpenman/valijson) — then hand the accepted
+  payload to qbuem-json for fast parsing / mapping:
+
+  ```cpp
+  // 1) validate untrusted text against the schema (dedicated lib, once, at the edge)
+  if (!schema_validator.is_valid(untrusted_text)) return reject();
+  // 2) parse the now-trusted bytes with qbuem-json (fast path)
+  auto doc = qbuem::read<RequestDto>(untrusted_text);
+  ```
+
+A single-header JSON parser and a Draft-2020-12 schema engine (with `$ref`
+resolution, recursive schemas, and format/pattern validators) are different
+tools; keeping them separate keeps this library single-header, zero-dependency,
+and fast, while letting you pair it with a best-in-class validator when you
+genuinely need runtime schema enforcement.
+
+---
+
 ## Memory safety — sanitizers
 
 Sanitizer CI runs on every push and pull request to `main` when `include/`,

--- a/docs/guide/vision.md
+++ b/docs/guide/vision.md
@@ -38,17 +38,21 @@ The full, sourced roadmap lives in [`ROADMAP.md`](https://github.com/qbuem/qbuem
 ## Tier 3 — Longer-term
 
 - ✅ **JSON diff / patch generation** — `qbuem::diff` + a complete functional RFC 6902 `apply_patch` (real-time state sync) *(v1.11.0)*.
-- ⬜ **JSON Schema** (Draft-7 → 2020-12 subset) validation — OpenAPI / MCP alignment.
-- ⬜ **Schemaless On-Demand lazy cursor** — parse only the values you touch.
-- ⬜ **Chunked / incremental (socket) parsing** — resumable feeding from a partial buffer.
-- 🚧 **Packaging** — `find_package(qbuem_json CONFIG)` fixed, Conan recipe + vcpkg port shipped, CI-verified *(v1.11.1)*; registry submission (ConanCenter / vcpkg) is the remaining step.
-- ⬜ **C++26 P2996 reflection backend** — macro-free registration as an *opt-in fast-lane* once stable
-  compilers ship (the macro stays the portable default).
+- ✅ **Packaging + conformance** — `find_package(qbuem_json CONFIG)`, Conan recipe + vcpkg port *(v1.11.1)*, and a full [JSONTestSuite conformance run](/guide/correctness#jsontestsuite-conformance) (283/283 mandatory cases under ASan+UBSan).
+- ❌ **JSON Schema** validation — **declined**: not differentiated (jsoncons / blaze / valijson already do it well), an L–XL subset would bloat the single header, and known C++ shapes get *compile-time* validation from `fuse<T>` already. We [document interop](/guide/correctness#json-schema-validation-interop) instead.
+- ❌ **Schemaless On-Demand lazy cursor** — **declined**: a simdjson parity-chase; the flat-tape DOM + `fuse` already cover our cases, and the iterator-invalidation semantics are high regression risk.
+- ⏸️ **Chunked / incremental (socket) parsing** — **deferred**: WebSocket frames and framed CBOR are already message-delimited, so a full message arrives before parse.
+- ⏸️ **C++26 P2996 reflection backend** — **gated** to stable compilers (~2028): macro-free registration as an *opt-in fast-lane* (the macro stays the portable default).
+
+The curated roadmap is **complete as of v1.13.0** — Tier 1, Tier 2, and the subset
+of Tier 3 that fits the library's identity are shipped; everything else above is a
+conscious decline/defer/gate. Further work is demand-driven, not roadmap-driven.
 
 ## Declined
 
 Speculative or niche items we are intentionally **not** pursuing (would fail the guiding rules):
 coroutine/async parsing, intra-document multithreading, constexpr JSON parsing; JMESPath / JSONata /
-jq embedding (JSONPath covers the query need); BSON, Amazon Ion, Apache Arrow/columnar,
-FlatBuffers/Cap'n Proto; and the old vision's "Protocol Shifting (SBE/FIX)", "IDL Inference", and
-"Nexus Codegen". (SVE, language bindings, and `std::pmr` from the old vision are **already shipped**.)
+jq embedding (JSONPath — now with filters — covers the query need); BSON, Amazon Ion, Apache
+Arrow/columnar, FlatBuffers/Cap'n Proto; and the old vision's "Protocol Shifting (SBE/FIX)", "IDL
+Inference", and "Nexus Codegen". (SVE, language bindings, and `std::pmr` from the old vision are
+**already shipped**.)


### PR DESCRIPTION
## Summary

**Roadmap curation decision — JSON Schema (Tier 3 #10): declined, document interop instead.**
Docs-only; no library change.

Per the "general-purpose / differentiated / no over-engineering" rules, shipping
our own JSON Schema validator is a poor fit:

1. **Not differentiated** — jsoncons (`jsonschema`), blaze, and valijson already
   do Draft-2020-12 well; a subset would *copy for parity* and invite
   "looks like Schema but isn't" frustration.
2. **Over-engineering** — even a subset is L–XL (`$ref` resolution, recursive
   schemas, format/pattern validators) and would bloat the single header.
3. **Our use case is covered** — `fuse<T>` / `QBUEM_JSON_FIELDS` give
   *compile-time* structural validation for known C++ shapes, stronger than a
   runtime schema check.

### Changes

- **`docs/guide/correctness.md`** — new "JSON Schema validation (interop)"
  section: prefer `fuse<T>` for known shapes; for dynamic/external schemas,
  validate at the trust boundary with a dedicated lib (jsoncons/blaze/valijson),
  then parse with qbuem-json for speed.
- **`ROADMAP.md` / `docs/guide/vision.md`** — #10 marked declined (with interop
  pointer), #12 declined, #13 deferred, #15 gated; the **curated roadmap is now
  complete as of v1.13.0**. Further work is demand-driven.

This closes out the curated Tier 1 → 2 → 3 execution: every remaining candidate
is a conscious decline / defer / gate, not an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
