### PR TITLE
docs: reposition for C++ SaaS backend + honest competitive-position read

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@
 
 **qbuem-json** is a high-performance C++20 JSON library with two complementary engines in a single header file.
 
+It is built to be the **JSON/CBOR serialization layer for a high-performance C++ backend on Linux**: parse request bodies into typed DTOs (macro-free for plain structs), serialize responses, and exchange compact, cross-language CBOR with a JS/TS web client. Fast and bounds-checked on untrusted input, zero dependencies. (Windows/MSVC is unsupported by design — the target is a Linux backend.)
+
 ---
 
 ## Two Engines, One Header
@@ -64,7 +66,7 @@
 | **API** | `qbuem::parse()` / `qbuem::read<T>()` | `qbuem::fuse<T>()` |
 | **How it works** | Builds a flat tape in one SIMD pass, then accesses values on demand | Streams JSON directly into struct fields — no tape, no intermediate representation |
 | **Allocation** | Single arena per document | Zero |
-| **Best for** | Dynamic keys, partial reads, mutations, arbitrary JSON | Fixed schemas, HFT, embedded, latency-critical DTOs |
+| **Best for** | Dynamic keys, partial reads, mutations, arbitrary JSON | Known-schema backend DTOs, low-latency services, latency-critical request handling |
 | **Throughput** | Up to 2.9 GB/s parse · 7.2 GB/s serialize | 50–230 ns struct mapping |
 
 ```cpp

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -97,7 +97,7 @@ export default withMermaid(
             ['meta', { name: 'theme-color', content: '#1a2744' }],
 
             // SEO - Core
-            ['meta', { name: 'keywords', content: 'C++ JSON, C++20 JSON library, fastest JSON parser, SIMD JSON, AVX-512 JSON, zero-allocation JSON, high-performance JSON, HFT JSON, JSON serializer, single header JSON, qbuem-json, CBOR C++, RFC 8949, binary serialization C++, C++ CBOR library, cbor-x interop, nlohmann alternative, simdjson alternative, RapidJSON alternative' }],
+            ['meta', { name: 'keywords', content: 'C++ JSON, C++20 JSON library, fastest JSON parser, SIMD JSON, AVX-512 JSON, zero-allocation JSON, high-performance JSON, C++ backend JSON, API DTO serialization, microservice JSON, JSON serializer, single header JSON, qbuem-json, CBOR C++, RFC 8949, binary serialization C++, C++ CBOR library, cbor-x interop, nlohmann alternative, simdjson alternative, RapidJSON alternative' }],
             ['meta', { name: 'author', content: 'qbuem-json Authors' }],
             ['meta', { name: 'robots', content: 'index, follow, max-image-preview:large' }],
 
@@ -185,7 +185,7 @@ export default withMermaid(
                         downloadUrl: 'https://github.com/qbuem/qbuem-json/releases/tag/v1.14.0',
                         installUrl: 'https://qbuem.com/qbuem-json/guide/getting-started',
                         license: 'https://www.apache.org/licenses/LICENSE-2.0',
-                        keywords: 'C++ JSON library, C++20 JSON, fastest JSON parser, SIMD JSON, AVX-512 JSON, zero-allocation JSON, high-performance JSON, HFT JSON, JSON serializer, single header JSON, header-only JSON, CBOR C++, RFC 8949 CBOR, binary serialization C++, nlohmann alternative, simdjson alternative, RapidJSON alternative',
+                        keywords: 'C++ JSON library, C++20 JSON, fastest JSON parser, SIMD JSON, AVX-512 JSON, zero-allocation JSON, high-performance JSON, C++ backend JSON, API DTO serialization, microservice JSON, JSON serializer, single header JSON, header-only JSON, CBOR C++, RFC 8949 CBOR, binary serialization C++, nlohmann alternative, simdjson alternative, RapidJSON alternative',
                         featureList: [
                             'AVX-512 and ARM NEON SIMD acceleration',
                             'Zero-allocation flat tape DOM',
@@ -350,7 +350,7 @@ export default withMermaid(
                                 name: 'What is Nexus Fusion and when should I use it?',
                                 acceptedAnswer: {
                                     '@type': 'Answer',
-                                    text: 'Nexus Fusion is qbuem-json\'s zero-tape engine. Instead of building a DOM tape first, it streams JSON bytes directly into struct fields using compile-time FNV-1a key hashing for O(1) dispatch. Use qbuem::fuse<T>() instead of qbuem::read<T>() when you need minimum latency (50–230 ns), such as in HFT tick data processing or real-time game state. Requires QBUEM_JSON_FIELDS registration.'
+                                    text: 'Nexus Fusion is qbuem-json\'s zero-tape engine. Instead of building a DOM tape first, it streams JSON bytes directly into struct fields using compile-time FNV-1a key hashing for O(1) dispatch. Use qbuem::fuse<T>() instead of qbuem::read<T>() when you need minimum latency (50–230 ns) on a known-schema DTO — e.g. the request-handling hot path of a high-throughput C++ backend. Requires QBUEM_JSON_FIELDS registration.'
                                 }
                             },
                             {

--- a/docs/guide/benchmarks.md
+++ b/docs/guide/benchmarks.md
@@ -26,27 +26,53 @@ Runs in parallel on three native GitHub-hosted runners (x86\_64 / Apple Silicon 
 
 ---
 
+## 🎯 Where qbuem-json fits — an honest competitive read
+
+qbuem-json is built to be the **JSON/CBOR serialization layer for a
+high-performance C++ backend**: parsing request bodies into typed DTOs,
+serializing responses, and exchanging compact binary with a web client. The
+honest position against the field (exact current numbers are on the live
+dashboard above — these are *directions*, not cherry-picked records):
+
+| Axis | Position | Notes |
+|:---|:---|:---|
+| **Struct decode** (known-schema DTO → C++) | **We lead** | The zero-tape `fuse<T>` engine streams bytes straight into fields; this is the request-handling hot path and our strongest axis. |
+| **Serialization** (C++ → JSON) | **We lead / parity** | Schubfach `double`→decimal + `yy-itoa`; ahead of `snprintf`/`to_chars`-based libraries, competitive with the fastest. |
+| **CBOR codec** | **We lead vs DOM libs** | ~20–28× a nlohmann `to_cbor`/`from_cbor`; at the hand-written TinyCBOR/QCBOR ceiling, but *bounds-checked* and from one field list. Few competitors ship a standard binary codec at all. |
+| **Schemaless parse throughput** (huge arbitrary doc) | **simdjson/yyjson can lead** | simdjson's lazy two-pass defers validation and wins pure streaming throughput; our one-pass tape pays a little for O(1) random access. We lead on *total* parse+access+serialize for typical request sizes. |
+| **All-in-one breadth, single header** | **Unique** | CBOR + JSONPath(+filters) + canonical + diff/patch + NDJSON + SAX + WASM + **macro-free reflection** in one zero-dep header. No single competitor matches the breadth at this speed. |
+| **Ergonomics** | **Now competitive** | Macro-free aggregate reflection (v1.14.0) closes the gap vs Glaze / reflect-cpp for plain DTOs. |
+
+**Honest non-goals:** we are **not** the absolute fastest at raw schemaless
+parsing of giant documents (reach for simdjson On-Demand there), and **Windows /
+MSVC is unsupported by design** (the target is a Linux C++ backend). If your
+workload is "parse a 1 GB log and touch three fields," simdjson is the better
+tool; if it is "(de)serialize typed API DTOs, fast and safely, with a binary path
+to a JS client," that is exactly what qbuem-json optimizes for.
+
+---
+
 ## 📦 CBOR Binary Codec {#cbor-binary-codec}
 
 The [CBOR codec](./cbor) reuses the same `QBUEM_JSON_FIELDS` registration as the JSON
 engine. These numbers are a focused micro-benchmark (Apple Silicon M-series,
 single core, `-O3 -march=native`, reused output buffer — the hot-loop pattern),
 separate from the live CI dashboard above. They measure two representative
-game-server payloads.
+backend payloads: a list/batch delta and a nested entity record.
 
 **CBOR vs JSON** — same struct, same data:
 
 | Payload | format | encode | decode | wire size |
 |:---|:---|---:|---:|---:|
-| AOI delta (16 entities × 7 ints) | **CBOR** | **515 ns** | **570 ns** | **590 B** |
-| AOI delta (16 entities × 7 ints) | JSON | 550 ns | 4309 ns | 1018 B |
-| Snapshot (8 players, nested/str/opt/vec) | **CBOR** | **409 ns** | **827 ns** | **880 B** |
-| Snapshot (8 players, nested/str/opt/vec) | JSON | 728 ns | 4557 ns | 1172 B |
+| List delta (16 items × 7 ints) | **CBOR** | **515 ns** | **570 ns** | **590 B** |
+| List delta (16 items × 7 ints) | JSON | 550 ns | 4309 ns | 1018 B |
+| Entity batch (8 records, nested/str/opt/vec) | **CBOR** | **409 ns** | **827 ns** | **880 B** |
+| Entity batch (8 records, nested/str/opt/vec) | JSON | 728 ns | 4557 ns | 1172 B |
 
 On the all-scalar hot path, CBOR **decode is ~7.5× faster than JSON** and the wire
 is **~42 % smaller**.
 
-**vs other CBOR codecs** — same payload (AOI delta), same map-keyed wire format:
+**vs other CBOR codecs** — same payload (the list delta), same map-keyed wire format:
 
 | Codec | encode | decode | notes |
 |:---|---:|---:|:---|

--- a/docs/guide/low-latency-patterns.md
+++ b/docs/guide/low-latency-patterns.md
@@ -1,6 +1,6 @@
 # Low-Latency Patterns
 
-qbuem-json is engineered for workloads where parsing overhead must not stall execution. These patterns apply to any domain that processes JSON at high throughput or under strict timing constraints — trading systems, game engines, web API gateways, embedded devices, and data pipelines.
+qbuem-json is engineered for workloads where parsing overhead must not stall execution. These patterns apply to any domain that processes JSON at high throughput or under strict timing constraints — high-throughput backend services and API gateways, data pipelines, embedded devices, and trading or game engines.
 
 The core principle is always the same: **allocate once, reuse forever**.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,8 +26,8 @@ features:
     details: "Flat tape DOM — no tree nodes, no pointer chasing. String views point directly into the input buffer. One contiguous array."
 
   - icon: 🔷
-    title: "Modern C++20 API"
-    details: "Concepts-based interface. No legacy SFINAE. Optional struct mapping via a single QBUEM_JSON_FIELDS macro."
+    title: "Macro-Free Struct Mapping"
+    details: "Concepts-based C++20 API. Plain aggregate structs serialize to JSON and CBOR with zero registration (field names via reflection) — ideal for backend DTOs. Add QBUEM_JSON_FIELDS only for renames, skip, or the fuse fast path."
 
   - icon: 🚀
     title: "Nexus Fusion Engine"
@@ -35,7 +35,7 @@ features:
 
   - icon: 🔒
     title: "RFC Compliant & Hardened"
-    details: "RFC 6901 JSON Pointer. RFC 6902 JSON Patch with transactional rollback. 521 tests · ASan, UBSan, TSan run on every commit · 11 libFuzzer targets."
+    details: "RFC 6901 JSON Pointer. RFC 6902 JSON Patch with transactional rollback. 100% JSONTestSuite conformance. 672 tests · ASan, UBSan, TSan run on every commit · 17 libFuzzer targets."
 
   - icon: 📦
     title: "Single Header · Apache 2.0"


### PR DESCRIPTION
Repoints the public copy to the library's actual north star — the JSON/CBOR layer for a high-performance **C++ backend** — and replaces vague 'fastest' framing with an honest read of where qbuem-json leads (struct decode, serialization, CBOR-vs-DOM, breadth) vs where it doesn't (raw schemaless parse of huge docs → simdjson; no Windows). Backend-neutral micro-bench payload names (same shapes/numbers), corrected stale counts (672 tests / 17 fuzz), macro-free struct-mapping feature card, backend-oriented FAQ + SEO keywords. Docs-only; the live CI dashboard remains the canonical number source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)