### PR TITLE
docs: full GitHub Pages audit & revision (16 files) for v1.15.0

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -103,7 +103,7 @@ export default withMermaid(
 
             // Open Graph
             ['meta', { property: 'og:title', content: 'qbuem-json — Feel the Power of Ultimate JSON Speed' }],
-            ['meta', { property: 'og:description', content: 'qbuem-json: small changes, big future. Bleeding-edge C++20 JSON library with AVX-512 SIMD acceleration, zero-allocation design, and single-header simplicity. Up to 2.7 GB/s parsing, 8.1 GB/s serialization.' }],
+            ['meta', { property: 'og:description', content: 'qbuem-json: small changes, big future. Bleeding-edge C++20 JSON library with AVX-512 SIMD acceleration, zero-allocation design, and single-header simplicity. Up to 2.9 GB/s parsing, 7.2 GB/s serialization.' }],
             ['meta', { property: 'og:image', content: 'https://qbuem.com/qbuem-json/banner.png' }],
             ['meta', { property: 'og:image:width', content: '989' }],
             ['meta', { property: 'og:image:height', content: '232' }],

--- a/docs/TEST_CASES.md
+++ b/docs/TEST_CASES.md
@@ -51,9 +51,9 @@ To mathematically and dynamically prove memory safety and the absence of undefin
 qbuem-json adheres to the "Zero-Cost" principle: you don't pay for the mutation features unless you use them.
 
 - **Read-Path Efficiency**: Accessors like `operator[]` and `at()` use `QBUEM_UNLIKELY` branch hints to check for mutations. For read-only documents, this cost is a single bit-check.
-- **Throughput Verification** (Release build, twitter.json):
-  - **Parsing**: ~227 μs (**2.7 GB/s**)
-  - **Serialization**: ~75 μs (**8.1 GB/s**)
+- **Throughput Verification** (Release build, twitter.json; see the live CI dashboard for current per-dataset numbers):
+  - **Parsing**: up to **~2.9 GB/s** (x86_64)
+  - **Serialization**: up to **~7.2 GB/s**
 - **No Regressions**: Comparisons against the baseline show 0% performance loss on cold-path (read-only) usage after RFC 6901/6902 integration.
 
 | **Leaks** | Memory Leaks | **PASS (0 byte)** |

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,6 +1,6 @@
 # API Reference
 
-A complete reference for all public APIs in qbuem-json v1.0.8.
+A complete reference for all public APIs in qbuem-json v1.15.0.
 
 > [!TIP]
 > Looking for auto-generated class/struct documentation? The **[Doxygen Reference](/qbuem-json/api/reference/index.html)** is rebuilt automatically whenever `qbuem_json.hpp` changes and deployed to Pages alongside this guide.

--- a/docs/guide/allocators.md
+++ b/docs/guide/allocators.md
@@ -1,59 +1,71 @@
-# Custom Allocators
+# Memory & Allocators
 
-qbuem-json is designed for environments where memory management is critical. It fully supports the C++17/20 **Polymorphic Memory Resource (PMR)** model, allowing you to control exactly where and how memory is allocated.
+qbuem-json is built for environments where memory management is critical — backend
+services handling many requests, low-latency paths, and constrained devices. Its
+primary memory model is a **single reusable arena per `Document`**, not a
+per-call allocator argument.
 
-## 🧠 Why Custom Allocators?
+## 🧠 The memory model
 
-While the default allocator is fast, certain scenarios benefit from specialized memory management:
-1. **Low Latency (HFT)**: Avoid system-wide locks in `malloc` by using thread-local pool allocators.
-2. **Embedded Systems**: Use a fixed-size stack buffer to ensure the parser never touches the heap.
-3. **Security**: Use "Scrubbing" allocators that zero-out memory after use.
+A parse does **not** allocate a tree of nodes. The DOM is a single flat **tape**
+(one contiguous arena) owned by the `Document` / `DocumentView`. That arena is
+**reused** across parses: after the first few requests the steady-state heap
+traffic is essentially zero, because the same buffer is refilled instead of
+re-allocated.
 
-## 🛠️ Using `std::pmr`
+There is intentionally **no** `parse(json, &resource)` or per-`Document`
+`memory_resource` argument — reuse is the lever, and it is simpler and faster than
+threading a resource through every call.
 
-The `qbuem::json::Document` class and the `parse` functions accept an optional `std::pmr::memory_resource*`.
+## 🔁 Reuse: allocate once, then never touch the heap
 
-### 1. Stack-Based Parsing (Zero Heap)
-Use a `std::pmr::monotonic_buffer_resource` with a stack-allocated array for absolute peak performance and zero heap noise.
+Keep one `Document` alive and re-parse into it. The arena grows to the high-water
+mark of your payloads and then stops allocating.
 
 ```cpp
-#include <memory_resource>
+#include <qbuem_json/qbuem_json.hpp>
 
-void process_small_json(std::string_view json) {
-    // 16KB stack buffer
-    std::byte buffer[1024 * 16];
-    std::pmr::monotonic_buffer_resource pool(buffer, sizeof(buffer));
-
-    // This document and its Tape will reside entirely on the stack
-    auto doc = qbuem::json::parse(json, &pool);
-    
-    // ... use doc ...
+void serve(/* a stream of request bodies */) {
+    qbuem::Document doc;                 // owns the reusable arena
+    for (std::string_view body : requests()) {
+        qbuem::Value root = qbuem::parse(doc, body);  // refills the SAME arena
+        // ... read fields off `root` ...
+        // Values are string_views into `body` + offsets into `doc`'s tape:
+        // finish using them before the next parse() reuses the tape.
+    }
 }
 ```
 
-### 2. Global Pool Allocators
-For high-concurrency servers, use a pool allocator to reduce contention.
+For a known-schema DTO, `qbuem::fuse<T>(body)` skips the tape entirely (zero-tape)
+— there is no document arena to reuse because there is no intermediate
+representation at all.
+
+## 🧩 PMR building blocks
+
+The header exposes `std::pmr`-based aliases for code that builds containers on top
+of the library:
 
 ```cpp
-std::pmr::synchronized_pool_resource global_pool;
-
-void on_request(std::string_view payload) {
-    auto doc = qbuem::json::parse(payload, &global_pool);
-    // ...
-}
+qbuem::json::String              s;   // = std::pmr::string
+qbuem::json::Vector<int>         v;   // = std::pmr::vector<int>
+qbuem::json::Allocator           a;   // = std::pmr::polymorphic_allocator<char>
 ```
 
-## 🏗️ Technical Details
+These honor the process-wide `std::pmr::get_default_resource()`, so setting a
+default pool affects code that uses them. Note that the DOM **tape** itself uses
+its own arena (not a user-supplied `memory_resource`), so a custom resource is not
+a substitute for `Document` reuse on the parse hot path.
 
-qbuem-json's internal `Tape` is a `std::pmr::vector<TapeNode>`. 
-- When a `memory_resource` is provided, the vector uses it for all growth operations.
-- All subsequent `Value` accessors and `dump()` operations inherit this memory context where appropriate.
+## 🚀 Performance impact
 
-## 🚀 Performance Impact
-
-Using a `monotonic_buffer_resource` for small-to-medium JSON documents typically results in a **15-20% speedup** in parsing time because it eliminates the overhead of the system's global heap manager.
+Reuse is the big win: the first parse pays the allocation, every subsequent parse
+into the same `Document` is allocation-free in steady state. Combine it with
+`fuse<T>` for known-schema request handling to remove the tape from the picture
+entirely.
 
 ---
 
 > [!TIP]
-> Combine custom allocators with [Document Reuse](/guide/low-latency-patterns#the-fundamental-pattern-document-reuse) for the ultimate steady-state optimization where memory is allocated once on startup and never touched again.
+> See [Low-Latency Patterns → Document Reuse](/guide/low-latency-patterns) for the
+> full steady-state pattern, and [Zero-Allocation Principle](/theory/zero-allocation)
+> for how the tape arena is laid out.

--- a/docs/guide/bindings.md
+++ b/docs/guide/bindings.md
@@ -8,7 +8,7 @@
 
 | Language | Binding Type | Maturity | Primary Use Case |
 | :--- | :--- | :--- | :--- |
-| **C++ &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;** | Native (Header-only) | Production | System programming, HFT, Games |
+| **C++ &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;** | Native (Header-only) | Production | Backend services, low-latency systems, DTO (de)serialization |
 | **C** | Shared Library (ABI) | Production | FFI Foundation, C Applications |
 | **Python** | `nanobind` / `ctypes` | Beta | Data Science, Rapid Prototyping |
 | **Rust** | `cxx` Bridge | Beta | Safe systems programming |

--- a/docs/guide/correctness.md
+++ b/docs/guide/correctness.md
@@ -5,7 +5,7 @@
   <a href="https://github.com/qbuem/qbuem-json/actions/workflows/sanitizers.yml"><img src="https://github.com/qbuem/qbuem-json/actions/workflows/sanitizers.yml/badge.svg" alt="Sanitizers (ASan · UBSan · TSan)" /></a>
   <a href="https://github.com/qbuem/qbuem-json/actions/workflows/benchmark.yml"><img src="https://github.com/qbuem/qbuem-json/actions/workflows/benchmark.yml/badge.svg" alt="Benchmark CI" /></a>
   <a href="https://github.com/qbuem/qbuem-json/actions/workflows/codeql.yml"><img src="https://github.com/qbuem/qbuem-json/actions/workflows/codeql.yml/badge.svg" alt="CodeQL" /></a>
-  <img src="https://img.shields.io/badge/tests-521%20passing-brightgreen" alt="521 tests passing" />
+  <img src="https://img.shields.io/badge/tests-675%20passing-brightgreen" alt="675 tests passing" />
   <img src="https://img.shields.io/badge/fuzz-17%20libFuzzer%20targets-orange" alt="17 libFuzzer targets" />
   <img src="https://img.shields.io/badge/RFC%208259-compliant-brightgreen" alt="RFC 8259" />
   <img src="https://img.shields.io/badge/RFC%206901-JSON%20Pointer-brightgreen" alt="RFC 6901" />
@@ -16,7 +16,7 @@
 <!-- Summary stats -->
 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(110px, 1fr)); gap: 0.75rem; background: linear-gradient(135deg, #f0f4ff, #e8f0ff); border: 1px solid #c0d0ff; border-radius: 12px; padding: 1.25rem 1.5rem; margin: 0 0 2rem; text-align: center;">
   <div>
-    <div style="font-size: 1.9rem; font-weight: 800; color: #1e2e5c; line-height: 1.1;">521</div>
+    <div style="font-size: 1.9rem; font-weight: 800; color: #1e2e5c; line-height: 1.1;">675</div>
     <div style="font-size: 0.78rem; color: #555; margin-top: 0.2rem;">tests passing</div>
   </div>
   <div>
@@ -32,7 +32,7 @@
     <div style="font-size: 0.78rem; color: #555; margin-top: 0.2rem;">sanitizers</div>
   </div>
   <div>
-    <div style="font-size: 1.9rem; font-weight: 800; color: #1e2e5c; line-height: 1.1;">11</div>
+    <div style="font-size: 1.9rem; font-weight: 800; color: #1e2e5c; line-height: 1.1;">17</div>
     <div style="font-size: 0.78rem; color: #555; margin-top: 0.2rem;">fuzz targets</div>
   </div>
 </div>
@@ -47,7 +47,7 @@ reproduce locally.
 
 | Signal | Status | Details |
 |:---|:---:|:---|
-| Total tests | **521** | 20 test files, 5,556 lines |
+| Total tests | **675** | 29 test files, ~7,700 lines |
 | RFC 8259 compliance tests | **73** | 23 accept · 24 reject · 8 impl-defined · 3 roundtrip · 3 API |
 | RFC 6901 JSON Pointer | ✅ | Pointer navigation + edge cases |
 | RFC 6902 JSON Patch | ✅ | add / remove / replace / move / copy / test ops, transactional rollback |
@@ -268,22 +268,29 @@ ctest --test-dir build_tsan --output-on-failure
 
 ## Fuzz testing
 
-Eleven [libFuzzer](https://llvm.org/docs/LibFuzzer.html) targets are maintained
-in `fuzz/`, providing exhaustive coverage of both core parsing and high-level structural mapping:
+Seventeen [libFuzzer](https://llvm.org/docs/LibFuzzer.html) targets are maintained
+in `fuzz/`, providing exhaustive coverage of core parsing, struct mapping, and
+every higher-level surface (CBOR, JSONPath, NDJSON, SAX, diff/patch, reflection):
 
 | Target | Input | Functionality Tested |
 |:---|:---|:---|
 | `fuzz_dom` | Arbitrary bytes | DOM parser — crash/hang on malformed input |
-| `fuzz_parse` | Arbitrary bytes | Nexus/struct-mapping path — type safety under adversarial data |
+| `fuzz_parse` | Arbitrary bytes | High-level `parse()` + full accessor surface |
 | `fuzz_rfc8259` | Arbitrary bytes | Strict parser — RFC 8259 acceptance/rejection consistency |
 | `fuzz_float` | Arbitrary bytes | Three-stage float parsing (Eisel-Lemire, Russ Cox) |
-| `fuzz_direct` | Arbitrary bytes | High-performance DirectParser (Zero-Tape) |
-| `fuzz_nexus` | Arbitrary bytes | Structural Nexus Fusion mapping |
-| `fuzz_api_stress` | Arbitrary bytes | mutation, SafeValue, and runtime API safety |
-| `fuzz_diff` | Arbitrary bytes | Differential testing vs `nlohmann/json` reference |
-| `fuzz_pmr.cpp` | Arbitrary bytes | Memory safety with `std::pmr` polymorphic allocators |
-| `fuzz_patch.cpp` | Arbitrary bytes | RFC 6902 (JSON Patch) exhaustive testing |
-| `fuzz_roundtrip.cpp` | Arbitrary bytes | Parse → Serialize → Re-parse identity validation |
+| `fuzz_direct` | Arbitrary bytes | DirectParser & key mapping (zero-tape) |
+| `fuzz_nexus` | Arbitrary bytes | Nexus Fusion struct mapping |
+| `fuzz_api_stress` | Arbitrary bytes | DOM mutation, SafeValue, runtime API safety |
+| `fuzz_roundtrip` | Arbitrary bytes | Parse → serialize → re-parse identity |
+| `fuzz_diff` | Arbitrary bytes | Differential testing vs `nlohmann/json` |
+| `fuzz_pmr` | Arbitrary bytes | Memory safety with `std::pmr` allocators |
+| `fuzz_patch` | Arbitrary bytes | JSON Pointer & in-place mutation |
+| `fuzz_cbor` | Arbitrary bytes | CBOR codec — decode hostile bytes + round-trip |
+| `fuzz_ndjson` | Arbitrary bytes | NDJSON line splitter + sub-view parse safety |
+| `fuzz_jsonpath` | Arbitrary bytes | JSONPath (RFC 9535) parser + evaluator, incl. filters |
+| `fuzz_sax` | Arbitrary bytes | SAX event visitor recursion + handler dispatch |
+| `fuzz_apply_patch` | Arbitrary bytes | RFC 6902 functional applier + diff generation |
+| `fuzz_reflect` | Arbitrary bytes | Macro-free aggregate reflection: JSON read + CBOR decode |
 
 ### Coverage Results
 
@@ -394,8 +401,8 @@ cmake --build build -j$(nproc)
 ctest --test-dir build --output-on-failure
 
 # Expected output:
-# 521/521 Test #521: StringEdge.SpecialKeyNames .......... Passed  0.00 sec
-# 100% tests passed, 0 tests failed out of 521
+# 675/675 Test #675: StringEdge.SpecialKeyNames .......... Passed  0.00 sec
+# 100% tests passed, 0 tests failed out of 675
 ```
 
 The test suite takes under 1 second on any modern machine.

--- a/docs/guide/debugging.md
+++ b/docs/guide/debugging.md
@@ -209,42 +209,36 @@ Explore every error category interactively — from what causes it to how to fix
 
 ### 🟢 Beginner: Catching and Reading Errors
 
-**All qbuem-json errors derive from `qbuem::json::error`.**
+**Malformed input throws `qbuem::parse_error`; type/access mistakes on the DOM (or
+Nexus) throw `std::runtime_error`.** There is no separate `type_error` /
+`access_error` hierarchy — catch `parse_error` then `std::runtime_error`.
 
 ```cpp
 #include <qbuem_json/qbuem_json.hpp>
 
 try {
-    auto doc  = qbuem::parse(input);
-    auto name = doc.root()["name"].as<std::string_view>();
-    auto age  = doc.root()["age"].as<int>();
+    qbuem::Document doc;
+    qbuem::Value root = qbuem::parse(doc, input);
+    auto name = root["name"].as<std::string_view>();
+    auto age  = root["age"].as<int>();
 }
 catch (const qbuem::parse_error& e) {
     // Malformed JSON — bad input from network, file, etc.
     std::cerr << "Parse failed: " << e.what()   << "\n";
-    std::cerr << "At byte:      " << e.position() << "\n";
-    std::cerr << "Context:      " << e.context()  << "\n";
-    // e.context() returns up to 20 bytes around the error site
+    std::cerr << "At byte:      " << e.offset() << "\n";
+    std::cerr << "Line/column:  " << e.line() << ":" << e.column() << "\n";
 }
-catch (const qbuem::type_error& e) {
-    // Wrong .as<T>() call
-    std::cerr << "Type error: " << e.what() << "\n";
-}
-catch (const qbuem::access_error& e) {
-    // Key not found, index out of range
-    std::cerr << "Access error: " << e.what() << "\n";
-}
-catch (const qbuem::json::error& e) {
-    // Catch-all for any qbuem-json error
-    std::cerr << "JSON error: " << e.what() << "\n";
+catch (const std::runtime_error& e) {
+    // Wrong .as<T>() type, missing key accessed throwingly, etc.
+    std::cerr << "Access/type error: " << e.what() << "\n";
 }
 ```
 
-**The three questions to ask when an error occurs:**
+**The questions to ask when an error occurs:**
 
-1. **What byte position?** — `e.position()` tells you exactly where in the input
-2. **What is the input around that position?** — `e.context()` shows the surrounding bytes
-3. **What type tag did the node have?** — a `type_error` tells you what tag was found vs. what was expected
+1. **What byte position?** — `e.offset()` (and `e.line()` / `e.column()`) tell you exactly where in the input.
+2. **Want a rendered caret?** — `qbuem::format_error(e, input)` returns the message with a `^` under the failure site.
+3. **Was it a type mistake?** — the `std::runtime_error::what()` says which `as<T>()` failed.
 
 ---
 
@@ -253,8 +247,8 @@ catch (const qbuem::json::error& e) {
 Always check before you extract:
 
 ```cpp
-auto doc  = qbuem::parse(input);
-auto root = doc.root();
+qbuem::Document doc;
+qbuem::Value root = qbuem::parse(doc, input);
 
 // ❌ Fragile — throws if key missing or wrong type
 auto name = root["name"].as<std::string_view>();
@@ -270,32 +264,31 @@ if (!name_val || !name_val->is_string()) {
 }
 auto name = name_val->as<std::string_view>();
 
-// ✅ Also safe — use the 'or_default' variant
-auto count = root["count"].as<int>(/*default=*/ 0);
+// ✅ Also safe — operator| supplies a default on missing/wrong type
+auto count = root["count"] | 0;
+// ✅ Or try_as<T>() for an explicit std::optional
+auto maybe = root["count"].try_as<int>();
 ```
 
 ---
 
 ### 🟡 Intermediate: Inspecting Error Context
 
-When you get a `parse_error`, the context string is your best diagnostic tool:
+When you get a `parse_error`, render the failure site with `format_error`:
 
 ```cpp
 catch (const qbuem::parse_error& e) {
-    auto pos = e.position();      // byte offset into input
-    auto ctx = e.context();       // up to 20 bytes around the error
-
-    // Print a visual position marker:
-    std::cerr << "Input:   " << std::string(ctx) << "\n";
-    std::cerr << "         " << std::string(pos % 20, ' ') << "^\n";
-    std::cerr << "Message: " << e.what() << "\n";
+    // line/column/offset are on the exception; format_error draws the caret.
+    std::cerr << "At " << e.line() << ":" << e.column()
+              << " (byte " << e.offset() << ")\n";
+    std::cerr << qbuem::format_error(e, input) << "\n"; // message + "^" marker
 }
 ```
 
-**Reading a `type_error` message:**
+**Reading a type-mismatch message:**
 
 <div class="bd-callout" style="font-size:0.82rem;">
-  <code>qbuem::type_error: expected INT64/UINT64, got STRING at tape[2]</code><br>
+  <code>qbuem::Value::as&lt;int64_t&gt;: not an integer (std::runtime_error)</code><br>
   <div class="bd-row" style="gap:2rem;margin-top:0.5rem;font-size:0.72rem;color:var(--vp-c-text-2);justify-content:flex-start;flex-wrap:wrap;">
     <span>↑ what you called <code>.as&lt;&gt;()</code> with</span>
     <span>↑ what the tape actually contains</span>
@@ -311,18 +304,20 @@ Check the TapeNode type tags table above to decode the tag name.
 For hot paths receiving untrusted input (network, files), validate cheaply before a full parse:
 
 ```cpp
-// Quick structural check — does not allocate
-bool looks_valid = qbuem::validate(input);
-
-// Check document size (prevent tape exhaustion DoS)
+// Reject oversized payloads up front (prevent tape-exhaustion DoS)
 if (input.size() > MAX_DOCUMENT_BYTES) {
     return reject("document too large");
 }
 
-// Only parse if validation passes
-if (looks_valid) {
-    auto root = qbuem::parse(doc, input);
+// rfc8259::validate() checks well-formedness (incl. UTF-8); it returns void and
+// THROWS qbuem::parse_error on the first violation.
+try {
+    qbuem::rfc8259::validate(input);     // strict structural + UTF-8 check
+    qbuem::Document doc;
+    qbuem::Value root = qbuem::parse(doc, input);
     // ...
+} catch (const qbuem::parse_error& e) {
+    return reject(e.what());
 }
 ```
 
@@ -371,42 +366,31 @@ ParseResult parse_and_keep(std::string json) {
 
 ### 🔴 Expert: Dumping the Tape
 
-When you have a hard-to-reproduce parse bug, dump the tape directly to understand what the parser saw:
+When you have a hard-to-reproduce parse bug, re-serialize what the parser captured
+and inspect each node's type tag:
 
 ```cpp
-#include <qbuem_json/qbuem_json.hpp>  // debug utilities
-
 qbuem::Document doc;
-auto root = qbuem::parse(doc, input);
+qbuem::Value root = qbuem::parse(doc, input);
 
-// Print the entire tape as human-readable text
-qbuem::debug::dump_tape(doc, std::cerr);
+// 1. Dump the parsed structure back to JSON — what the parser actually saw.
+std::cerr << root.dump() << "\n";          // compact
+std::cerr << root.dump(2) << "\n";         // pretty (2-space indent)
+
+// 2. Inspect a node's type tag directly.
+std::cerr << "root is: " << root.type_name() << "\n";        // "object", "array", ...
+for (const auto& [key, val] : root.items())
+    std::cerr << key << " : " << val.type_name() << "\n";
 ```
 
-Sample output:
-
-```
-TapeArena — 6 nodes, capacity 256
-────────────────────────────────────────────────────────
-tape[0]  OBJ_START  tag=0x01  jump→5
-tape[1]  KEY        tag=0x05  ptr=0x7ffe1234  len=2  → "id"
-tape[2]  INT64      tag=0x08  value=42
-tape[3]  KEY        tag=0x05  ptr=0x7ffe1238  len=6  → "active"
-tape[4]  BOOL_TRUE  tag=0x0A
-tape[5]  OBJ_END    tag=0x02  jump→0
-────────────────────────────────────────────────────────
-Input buffer: 0x7ffe1230  length: 26
-Stage1Index:  24 structural positions
-```
-
-**What to look for in the dump:**
+**What to look for:**
 
 | Symptom | Cause |
 |:---|:---|
-| Node count much lower than expected | Parser stopped early — check for errors |
-| KEY node count ≠ STRING node count | Malformed object (missing value for a key) |
-| Jump index points to wrong node | Nested depth mismatch — mismatched braces |
-| STRING ptr very different from KEY ptr | Input buffer layout issue |
+| `dump()` shows fewer fields than the input | Parser stopped early — check for a `parse_error` |
+| A field's `type_name()` is `"null"`/missing | Key absent, or a malformed object (missing value for a key) |
+| Numbers came back as strings (or vice versa) | The input had quotes where you expected a number, or vice versa |
+| Nested structure looks truncated | Mismatched braces / exceeded `kMaxDepth` (1024) |
 | `DOUBLE` where you expected `INT64` | Number has a decimal point or exponent in JSON |
 
 ---
@@ -485,7 +469,7 @@ Use this when an error occurs and you're not sure where to start:
 ### Type errors
 
 <div class="bd-checklist">
-  <div class="bd-checklist-item">What does <code>dump_tape()</code> show as the actual type tag?</div>
+  <div class="bd-checklist-item">What does <code>value.type_name()</code> report as the actual type?</div>
   <div class="bd-checklist-item">Did you call <code>.as&lt;int&gt;()</code> on a float like <code>1.0</code>? Use <code>.as&lt;double&gt;()</code> instead.</div>
   <div class="bd-checklist-item">Did you call <code>.as&lt;string_view&gt;()</code> on a key that might not exist? Use <code>.find()</code> first.</div>
   <div class="bd-checklist-item">Are array indices zero-based and within range?</div>

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -71,7 +71,7 @@ target_link_libraries(your_target PRIVATE qbuem_json::qbuem_json)
 
 ```bash
 conan create . -s compiler.cppstd=20      # build & test the package locally
-# in your conanfile: requires = "qbuem-json/1.11.1"
+# in your conanfile: requires = "qbuem-json/1.15.0"
 ```
 
 **vcpkg** — an overlay port ships under `ports/qbuem-json/`:

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -28,7 +28,9 @@ The two engines handle different shapes of work. DOM is the right choice when th
 - Schubfach dtoa for shortest round-trip float serialization
 - yy-itoa for integer serialization without division
 - Russ Cox algorithm for decimal-to-double parsing
-- JSON Pointer (RFC 6901) and JSON Patch (RFC 6902)
-- Language bindings for Python and Go
+- JSON Pointer (RFC 6901), JSON Patch / diff (RFC 6902), JSONPath (RFC 9535, incl. filter selectors)
+- CBOR (RFC 8949) binary codec from the same struct registration — cross-language
+- Macro-free struct mapping for plain aggregates; `read_strict` for required-field enforcement
+- Language bindings for Python, Go, Rust, C, and WebAssembly
 
 [Getting Started](/guide/getting-started) has the install step and first example.

--- a/docs/guide/low-latency-patterns.md
+++ b/docs/guide/low-latency-patterns.md
@@ -123,30 +123,32 @@ void handle_request(std::string_view body, HttpResponse& resp) {
 
 ---
 
-### Embedded & IoT
+### Embedded & constrained devices
 
-On microcontrollers or systems without a reliable heap, use `std::pmr` to parse directly into a stack-allocated buffer — **no heap involved at all**:
+On constrained devices, hold one long-lived `Document` (or use the zero-tape
+`fuse<T>`) so the steady state never touches the heap — the tape arena is allocated
+once and refilled on every packet:
 
 ```cpp
-#include <memory_resource>
+void sensor_loop() {
+    qbuem::Document doc;                 // one reusable arena for the lifetime
+    for (std::string_view pkt : packets()) {
+        qbuem::Value root = qbuem::parse(doc, pkt);   // refills the same arena
 
-void handle_sensor_packet(std::string_view json) {
-    // 16 KB lives entirely on the stack
-    alignas(std::max_align_t) std::byte buf[16 * 1024];
-    std::pmr::monotonic_buffer_resource pool(buf, sizeof(buf));
+        float temp   = root["temp"].as<double>();
+        int   sensor = root["id"].as<int64_t>();
+        bool  alarm  = root["alarm"] | false;
 
-    auto doc  = qbuem::json::parse(json, &pool);
-    auto root = doc.root();
-
-    float  temp   = root["temp"].as<double>();
-    int    sensor = root["id"].as<int64_t>();
-    bool   alarm  = root["alarm"] | false;
-
-    publish_reading(sensor, temp, alarm);
-} // buf goes out of scope — nothing to free, no allocator lock
+        publish_reading(sensor, temp, alarm);
+        // `root`'s values view `pkt` + `doc`'s tape — finish before the next parse.
+    }
+}
 ```
 
-Suitable for hard real-time constraints where heap latency is non-deterministic. Combine with `doc.reserve()` if the stack buffer must be sized precisely.
+For a fixed packet schema, `qbuem::fuse<SensorReading>(pkt)` skips the tape
+entirely (no document arena at all) — the lowest-latency, lowest-footprint path.
+Heap traffic in both patterns is zero in steady state, which is what hard
+real-time constraints need.
 
 ---
 

--- a/docs/guide/mapping.md
+++ b/docs/guide/mapping.md
@@ -464,56 +464,56 @@ QBUEM_JSON_FIELDS(Transform, position, rotation)  // glm::vec3 is automatically 
 
 ---
 
-## 🎮 Complete Real-World Example
+## 🧩 Complete Real-World Example
 
-Here's how qbuem-json handles a full game player profile:
+Here's how qbuem-json handles a full backend account-API response:
 
 ```cpp
-struct Stats {
-    int    kills    = 0;
-    int    deaths   = 0;
-    double kd_ratio = 0.0;
+struct Usage {
+    int64_t api_calls  = 0;
+    int64_t storage_mb = 0;
+    double  cost_usd   = 0.0;
 };
-QBUEM_JSON_FIELDS(Stats, kills, deaths, kd_ratio)
+QBUEM_JSON_FIELDS(Usage, api_calls, storage_mb, cost_usd)
 
-struct Equipment {
-    std::string weapon;
-    std::string armor;
-    std::vector<std::string> consumables;
+struct Plan {
+    std::string tier;
+    std::string renews_on;
+    std::vector<std::string> features;
 };
-QBUEM_JSON_FIELDS(Equipment, weapon, armor, consumables)
+QBUEM_JSON_FIELDS(Plan, tier, renews_on, features)
 
-struct Player {
+struct Account {
     uint64_t    id;
-    std::string name;
-    int         level   = 1;
-    Stats       stats;
-    Equipment   equip;
-    std::optional<std::string> guild;
-    std::vector<std::string>   achievements;
+    std::string email;
+    int         seats   = 1;
+    Usage       usage;
+    Plan        plan;
+    std::optional<std::string> org;
+    std::vector<std::string>   roles;
 };
-QBUEM_JSON_FIELDS(Player, id, name, level, stats, equip, guild, achievements)
+QBUEM_JSON_FIELDS(Account, id, email, seats, usage, plan, org, roles)
 
 int main() {
-    // --- Deserialize from API response ---
+    // --- Deserialize an API response ---
     std::string api_json = R"({
-        "id": 123456, "name": "DragonSlayer", "level": 87,
-        "stats": {"kills": 500, "deaths": 42, "kd_ratio": 11.9},
-        "equip": {"weapon": "Excalibur", "armor": "Dragon Mail", "consumables": ["Potion", "Elixir"]},
-        "guild": "Knights of qbuem",
-        "achievements": ["First Blood", "Legend"]
+        "id": 123456, "email": "ada@example.com", "seats": 25,
+        "usage": {"api_calls": 1840221, "storage_mb": 4096, "cost_usd": 119.90},
+        "plan": {"tier": "business", "renews_on": "2026-07-01", "features": ["sso", "audit-log"]},
+        "org": "Acme Inc",
+        "roles": ["admin", "billing"]
     })";
 
-    Player p = qbuem::read<Player>(api_json);
-    std::cout << p.name << " (Level " << p.level << ")\n";
-    std::cout << "K/D: " << p.stats.kd_ratio << "\n";
-    std::cout << "Guild: " << p.guild.value_or("No Guild") << "\n";
+    Account a = qbuem::read<Account>(api_json);
+    std::cout << a.email << " (" << a.seats << " seats)\n";
+    std::cout << "Spend: $" << a.usage.cost_usd << "\n";
+    std::cout << "Org: " << a.org.value_or("(personal)") << "\n";
 
-    // --- Modify and Serialize back ---
-    p.level = 88;
-    p.achievements.push_back("Legendary Warrior");
+    // --- Modify and serialize back ---
+    a.seats = 30;
+    a.roles.push_back("auditor");
 
-    std::string updated_json = qbuem::write(p, 2); // pretty-print
+    std::string updated_json = qbuem::write(a, 2); // pretty-print
     std::cout << updated_json << "\n";
 }
 ```

--- a/docs/guide/vision.md
+++ b/docs/guide/vision.md
@@ -45,9 +45,11 @@ The full, sourced roadmap lives in [`ROADMAP.md`](https://github.com/qbuem/qbuem
 - ⏸️ **Chunked / incremental (socket) parsing** — **deferred**: WebSocket frames and framed CBOR are already message-delimited, so a full message arrives before parse.
 - ⏸️ **C++26 P2996 reflection backend** — **gated** to stable compilers (~2028): macro-free registration as an *opt-in fast-lane* (the macro stays the portable default).
 
-The curated roadmap is **complete as of v1.13.0** — Tier 1, Tier 2, and the subset
-of Tier 3 that fits the library's identity are shipped; everything else above is a
-conscious decline/defer/gate. Further work is demand-driven, not roadmap-driven.
+The curated roadmap is **complete as of v1.15.0** — Tier 1, Tier 2, and the subset
+of Tier 3 that fits the library's identity are shipped (including macro-free
+aggregate reflection in v1.14.0 and `read_strict<T>` strict deserialization in
+v1.15.0); everything else above is a conscious decline/defer/gate. Further work is
+demand-driven, not roadmap-driven.
 
 ## Declined
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ features:
 
   - icon: 🔒
     title: "RFC Compliant & Hardened"
-    details: "RFC 6901 JSON Pointer. RFC 6902 JSON Patch with transactional rollback. 100% JSONTestSuite conformance. 672 tests · ASan, UBSan, TSan run on every commit · 17 libFuzzer targets."
+    details: "RFC 6901 JSON Pointer. RFC 6902 JSON Patch with transactional rollback. 100% JSONTestSuite conformance. 675 tests · ASan, UBSan, TSan run on every commit · 17 libFuzzer targets."
 
   - icon: 📦
     title: "Single Header · Apache 2.0"
@@ -88,7 +88,7 @@ features:
 
 ## Why qbuem-json?
 
-**qbuem-json** was built for production systems where latency and allocation count — HFT tick data, real-time game state, large-scale data pipelines. Every design decision is measurable: benchmarks run on CI across three architectures, 521 automated tests guard correctness, and the library ships as a single header with zero dependencies.
+**qbuem-json** is the JSON/CBOR serialization layer for high-performance C++ backends on Linux — parsing request bodies into typed DTOs, serializing responses, and exchanging compact binary with a web client, all where latency and allocation count. Every design decision is measurable: benchmarks run on CI across three architectures, 675 automated tests guard correctness, and the library ships as a single header with zero dependencies.
 
 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1.25rem; margin: 2rem 0;">
 
@@ -184,7 +184,7 @@ Choose the DOM engine when key names are dynamic or unknown at compile time. Swi
 include(FetchContent)
 FetchContent_Declare(qbuem_json
     GIT_REPOSITORY https://github.com/qbuem/qbuem-json.git
-    GIT_TAG        v1.0.8
+    GIT_TAG        v1.15.0
 )
 FetchContent_MakeAvailable(qbuem_json)
 target_link_libraries(my_target PRIVATE qbuem_json::qbuem_json)
@@ -209,7 +209,7 @@ to CI you can inspect:
 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; margin: 1.5rem 0 2rem;">
 
 <div style="background: #f0f4ff; border: 1px solid rgba(30,46,92,0.15); border-radius: 10px; padding: 1.1rem;">
-  <div style="font-weight: 700; color: #1e2e5c; margin-bottom: 0.4rem;">521 tests · 20 files</div>
+  <div style="font-weight: 700; color: #1e2e5c; margin-bottom: 0.4rem;">675 tests · 29 files</div>
   <div style="color: rgba(30,46,92,0.7); font-size: 0.86rem; line-height: 1.55;">5,556 lines of C++ tests covering DOM, Nexus, STL mapping, error handling, Unicode, and edge cases.  <a href="/qbuem-json/guide/correctness">Details →</a></div>
 </div>
 

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -3,7 +3,7 @@
 > qbuem-json is a high-performance, header-only C++20 JSON library with dual-engine architecture.
 > GitHub: https://github.com/qbuem/qbuem-json
 > Docs: https://qbuem.com/qbuem-json/
-> Version: 1.0.8 · License: Apache 2.0
+> Version: 1.15.0 · License: Apache 2.0
 
 ---
 
@@ -44,7 +44,7 @@ include(FetchContent)
 FetchContent_Declare(
     qbuem_json
     GIT_REPOSITORY https://github.com/qbuem/qbuem-json
-    GIT_TAG        v1.0.8
+    GIT_TAG        v1.15.0
 )
 FetchContent_MakeAvailable(qbuem_json)
 target_link_libraries(your_target PRIVATE qbuem_json::qbuem_json)
@@ -553,7 +553,7 @@ CBOR codec (Apple Silicon, 16-entity × 7-int message, reused buffer): encode ~5
 - IEEE 754 round-trip: `parse(serialize(x)) == x` for all finite doubles
 - Three-stage float parsing: Eisel-Lemire (~98.8%) → Russ Cox Unrounded Scaling (~1.2%) → strtod (subnormals <0.01%)
 - Float serialization: Schubfach (Giulietti 2020) — shortest decimal, no trailing zeros
-- 672 passing tests; CBOR decoder is bounds-checked and safe on untrusted input
+- 675 passing tests; CBOR decoder is bounds-checked and safe on untrusted input
 - 17 libFuzzer targets (including dedicated CBOR and reflection fuzzers)
 - ASan, UBSan, TSan on every commit
 

--- a/docs/theory/russ-cox.md
+++ b/docs/theory/russ-cox.md
@@ -27,7 +27,7 @@ Standard library functions like `strtod` and `atof` are notoriously slow for hig
   </div>
 </div>
 
-`STMXCSR` / `LDMXCSR` are **serializing instructions** — they prevent the CPU from executing any subsequent instruction until the FPU state is written back to memory. For a parser targeting 2.7 GB/s, even a single `strtod` call per number would destroy all SIMD gains.
+`STMXCSR` / `LDMXCSR` are **serializing instructions** — they prevent the CPU from executing any subsequent instruction until the FPU state is written back to memory. For a parser targeting ~2.9 GB/s, even a single `strtod` call per number would destroy all SIMD gains.
 
 ---
 

--- a/docs/theory/simd.md
+++ b/docs/theory/simd.md
@@ -259,7 +259,7 @@ NEON has no `VCOMPRESSB` equivalent. qbuem-json uses a `VBSL`-based gather with 
 | ARM NEON | 128-bit Q | ~4 bytes/cycle | ~12 GB/s |
 | Scalar reference | 8-bit GPR | ~1 byte/cycle | ~3 GB/s |
 
-End-to-end parse throughput (2.7 GB/s) is below the Stage-1 ceiling because memory bandwidth and Stage-2 tape generation are the bottleneck for large documents.
+End-to-end parse throughput (up to ~2.9 GB/s on x86_64, ~2.5 on Apple Silicon) is below the Stage-1 ceiling because memory bandwidth and Stage-2 tape generation are the bottleneck for large documents.
 
 ---
 


### PR DESCRIPTION
Exhaustive audit of the docs site (3 parallel reviewers over guides/theory/llms/README/index/config) + fixes. **Docs-only.**

- **Version/count staleness:** stale install pins that pulled ancient versions (`GIT_TAG v1.0.8`, Conan `1.11.1`, api `v1.0.8`); test count 521/672→675; fuzz 11/12/3→17 (and the correctness.md fuzz-target table rebuilt to the real 17); throughput 2.7→~2.9 GB/s.
- **Compile-breaking examples rewritten to the real API:** allocators.md (fictional `parse(json,&resource)` PMR → real Document-reuse model), low-latency embedded example, and debugging.md (non-existent `type_error`/`access_error`/`json::error`, `e.position()/.context()`, `bool validate`, `debug::dump_tape`, `parse(input)+doc.root()` → correct API).
- **Missing features added:** introduction (JSONPath/CBOR/reflection/read_strict), vision (read_strict + complete-as-of-v1.15.0).
- **Positioning:** games/HFT → C++ backend (index hero, mapping main example, bindings).

vitepress build exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)