### PR TITLE
chore(ci): only commit benchmark results from a push to main

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -477,6 +477,11 @@ jobs:
         GITHUB_REF_NAME: ${{ github.ref_name }}
 
     - name: Commit benchmark results to main
+      # Only write results back from a real push to main. Without this guard the
+      # step runs on workflow_dispatch against a feature branch and `git push
+      # origin HEAD:main` fast-forwards main to that branch's tip — i.e. any branch
+      # dispatch silently lands unreviewed commits on main.
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
       run: |
         git config user.name  "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
The benchmark workflow's "Commit benchmark results to main" step ran on **every** invocation — including `workflow_dispatch` on a feature branch — and did `git push origin HEAD:main`. From a branch run, that fast-forwards `main` to the branch tip, silently landing unreviewed commits on main.

This was observed live: dispatching the benchmark on a fix branch to verify the Rust-bench link pushed that branch's commit onto main as a side effect.

**Fix:** guard the step with `github.ref == 'refs/heads/main' && github.event_name == 'push'`. Branch dispatches still produce the step summary + per-platform artifacts (enough to verify a fix) but can no longer write to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)