### PR TITLE
fix(docs): restore Doxygen project name/version + real landing page

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1,8 +1,8 @@
 # Doxyfile 1.9.1
 
-PROJECT_NAME           = "Beast JSON"
-PROJECT_NUMBER         = "1.0.5"
-PROJECT_BRIEF          = "The fastest C++20 JSON library you can drop into any project — single header, zero dependencies."
+PROJECT_NAME           = "qbuem-json"
+PROJECT_NUMBER         = "1.16.0"
+PROJECT_BRIEF          = "Single-header C++20 JSON + CBOR library — dual-engine SIMD DOM and zero-tape struct mapping. Zero dependencies."
 
 OUTPUT_DIRECTORY       = docs/api/
 CREATE_SUBDIRS         = NO
@@ -24,15 +24,15 @@ HIDE_IN_BODY_DOCS      = NO
 INTERNAL_DOCS          = NO
 
 # Input Related
-# Header only: the API reference is generated from the canonical source, which is
-# always in sync. The old INPUT also pulled in three hand-written docs/*.md files
-# that had drifted out of date; they were removed (their accurate replacements
-# live in the VitePress guide/theory pages).
-INPUT                  = include/qbuem_json/qbuem_json.hpp
-FILE_PATTERNS          = *.hpp *.h
+# The API reference is generated from the canonical header (always in sync) plus a
+# single small, purpose-built landing page (docs/api-mainpage.md). The old INPUT
+# pulled in three hand-written docs that had drifted out of date; those were
+# removed (their accurate replacements live in the VitePress guide/theory pages).
+INPUT                  = include/qbuem_json/qbuem_json.hpp docs/api-mainpage.md
+FILE_PATTERNS          = *.hpp *.h *.md
 RECURSIVE              = YES
 EXCLUDE_PATTERNS       =
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = docs/api-mainpage.md
 
 # HTML Related
 HTML_OUTPUT            = reference

--- a/docs/api-mainpage.md
+++ b/docs/api-mainpage.md
@@ -1,0 +1,32 @@
+# qbuem-json — API Reference {#mainpage}
+
+This is the auto-generated **API reference** for `qbuem-json`, a single-header,
+zero-dependency C++20 JSON + CBOR library. It is generated directly from the
+library header, so it always matches the source.
+
+- **Full guide, tutorials, and architecture:** <https://qbuem.com/qbuem-json/>
+- **Source, releases, and issues:** <https://github.com/qbuem/qbuem-json>
+
+## Where to start
+
+Register a struct once with `QBUEM_JSON_FIELDS(T, field1, field2, ...)` (at
+**namespace scope**, outside the struct) and it works across every entry point below:
+
+| Task | API |
+|------|-----|
+| Parse to a navigable/mutable DOM | `qbuem::parse(Document&, std::string_view)` → `qbuem::Value` |
+| Map JSON straight into a struct | `qbuem::read<T>()` (tape) · `qbuem::fuse<T>()` (zero-tape) |
+| Reject missing required fields | `qbuem::read_strict<T>()` |
+| Serialize a struct to JSON | `qbuem::write()` · `qbuem::write_to()` (reused buffer) |
+| Binary codec (RFC 8949) | `qbuem::cbor::encode<T>()` / `qbuem::cbor::decode<T>()` |
+| Canonical JSON (RFC 8785) | `qbuem::canonicalize()` |
+| JSONPath query (RFC 9535) | `qbuem::query()` |
+| JSON diff / patch (RFC 6902) | `qbuem::diff()` / `qbuem::apply_patch()` |
+
+> **Lifetime note.** A `Value`/`Document` holds a non-owning view into the bytes you
+> parse, so the input buffer must outlive every `Value`. Passing a temporary
+> `std::string` to `parse` is a compile error (the rvalue overload is deleted); the
+> copying `read<T>()` / `fuse<T>()` take a `string_view` and are safe with temporaries.
+
+Browse the **Classes** and **Files** in the navigation for the complete reference.
+Supported platforms: Linux (x86_64 / aarch64) and macOS (Apple Silicon), GCC and Clang.


### PR DESCRIPTION
The live Doxygen reference (qbuem.com/qbuem-json/api/reference/) showed a stale **"Beast JSON 1.0.5"** title and — after the header-only INPUT change in #160 — an **empty landing page**.

- **Stale title (pre-existing):** `PROJECT_NAME "Beast JSON" → "qbuem-json"`, `PROJECT_NUMBER "1.0.5" → "1.16.0"`, refreshed `PROJECT_BRIEF`.
- **Empty landing page (regression from #160):** the header's top block is an `@brief`/changelog, not an `@mainpage`, and `USE_MDFILE_AS_MAINPAGE` had been cleared. Added a small, accurate, purpose-built **`docs/api-mainpage.md`** (entry-point table + lifetime caveat + link to the full VitePress docs) and wired it via `USE_MDFILE_AS_MAINPAGE`. This is NOT one of the stale legacy docs #160 removed — it's a fresh, maintained landing page; the API content still comes from the header.

**Verified locally:** `doxygen Doxyfile` clean (exit 0, no warnings); `index.html` now titled **"qbuem-json — API Reference"**, version **1.16.0**, with a populated main page. Generated output stays gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)