### PR TITLE
docs: document macro-free fuse across pages (fix stale 'fuse needs the macro')

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Windows/MSVC is intentionally unsupported by design.
 
 ## [Unreleased]
 
+### Added
+- **Macro-free `fuse<T>` for aggregates.** The zero-tape Nexus engine now works on a
+  plain aggregate with no `QBUEM_JSON_FIELDS` — including generic (template) and nested
+  aggregates — completing the macro-free story (already true for `read` / `write` /
+  `read_strict` / CBOR). Key→field routing uses a reflected compile-time-hash ladder; the
+  macro's compile-time `switch` stays the peak-dispatch path for very wide hot-path
+  structs (~1.5× on a realistic DTO, growing with field count). GCC/Clang, plain
+  aggregate, ≤32 fields. A `QBUEM_JSON_FIELDS` registration always wins when present.
+
 ### Fixed
 - **Rust binding benchmark produced no numbers in CI.** `bindings/rust/build.rs`
   was matched by an over-broad `build*` `.gitignore` rule and had never been

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -199,7 +199,7 @@ export default withMermaid(
                             '675 passing tests, 17 libFuzzer targets',
                             'STL container support (vector, map, optional, tuple, variant)',
                             'Enum support: integer by default, value-name via QBUEM_JSON_ENUM (JSON + CBOR)',
-                            'Macro-free aggregate reflection: plain structs serialize/deserialize (JSON + CBOR) with no QBUEM_JSON_FIELDS registration (GCC/Clang)',
+                            'Macro-free aggregate reflection: plain structs serialize/deserialize across JSON, CBOR, and the zero-tape fuse<T> with no QBUEM_JSON_FIELDS registration — including generic and nested aggregates (GCC/Clang)',
                             'Strict deserialization (qbuem::read_strict): missing required (non-optional) fields throw, for safe backend request DTOs',
                             'Field rename (member, "jsonKey") and skip-by-omission, across JSON/fuse/CBOR',
                             'NDJSON / JSON Lines streaming (read_lines / write_lines) in bounded memory',
@@ -351,7 +351,7 @@ export default withMermaid(
                                 name: 'What is Nexus Fusion and when should I use it?',
                                 acceptedAnswer: {
                                     '@type': 'Answer',
-                                    text: 'Nexus Fusion is qbuem-json\'s zero-tape engine. Instead of building a DOM tape first, it streams JSON bytes directly into struct fields using compile-time FNV-1a key hashing for O(1) dispatch. Use qbuem::fuse<T>() instead of qbuem::read<T>() when you need minimum latency (50–230 ns) on a known-schema DTO — e.g. the request-handling hot path of a high-throughput C++ backend. Requires QBUEM_JSON_FIELDS registration.'
+                                    text: 'Nexus Fusion is qbuem-json\'s zero-tape engine. Instead of building a DOM tape first, it streams JSON bytes directly into struct fields, routing each key by a compile-time key hash for O(1) dispatch. Use qbuem::fuse<T>() instead of qbuem::read<T>() when you need minimum latency (50–230 ns) on a known-schema DTO — e.g. the request-handling hot path of a high-throughput C++ backend. Register the struct with QBUEM_JSON_FIELDS for the macro\'s compile-time switch dispatch, or — on GCC/Clang — fuse a plain aggregate (including generic and nested) macro-free via reflection, at a small dispatch cost on very wide structs.'
                                 }
                             },
                             {

--- a/docs/guide/parsing.md
+++ b/docs/guide/parsing.md
@@ -82,7 +82,7 @@ auto user = qbuem::read<User>(R"({"name": "Alice", "age": 30})");
 
 ### `qbuem::fuse<T>(json)` — Direct Fusion (Nexus Engine)
 
-The **lowest-latency** way to parse. It bypasses the Tape entirely and streams JSON directly into your struct. Requires your struct to be registered via `QBUEM_JSON_FIELDS`.
+The **lowest-latency** way to parse. It bypasses the Tape entirely and streams JSON directly into your struct. Register the struct with `QBUEM_JSON_FIELDS` for the macro's `O(1)` compile-time `switch` dispatch — or, on GCC/Clang, skip the macro entirely: a plain aggregate (incl. generic and nested) fuses [macro-free](/guide/mapping#macro-free-mapping-aggregate-reflection) via reflection, at a small dispatch cost on very wide structs.
 
 ```cpp
 // 0.0 Tape Allocation. O(1) Perfect Hash Dispatch.

--- a/docs/guide/vision.md
+++ b/docs/guide/vision.md
@@ -22,7 +22,7 @@ The full, sourced roadmap lives in [`ROADMAP.md`](https://github.com/qbuem/qbuem
 
 ## Tier 1
 
-- ✅ **Macro-free aggregate reflection** *(v1.14.0, GCC/Clang)* — plain aggregate structs serialize/deserialize across JSON and CBOR with no `QBUEM_JSON_FIELDS` (field names via reflection); the macro/registration always wins, so it is purely additive. Built for backend DTOs.
+- ✅ **Macro-free aggregate reflection** *(v1.14.0+, GCC/Clang)* — plain aggregate structs serialize/deserialize across JSON, CBOR, and the zero-tape `fuse<T>` (including generic and nested aggregates) with no `QBUEM_JSON_FIELDS` (field names via reflection); the macro/registration always wins, so it is purely additive. For `fuse<T>` the macro's compile-time `switch` is still the peak dispatch on very wide hot-path structs. Built for backend DTOs.
 - ✅ **Rich error context** — `parse_error` exposes line/column + `format_error()` caret rendering *(v1.3.0)*.
 - ✅ **serde-style field attributes** — enum (integer default + `QBUEM_JSON_ENUM` value names) *(v1.4.0)*, field rename `(member, "jsonKey")` + skip-by-omission *(v1.5.0)*, default-on-absent (built in).
 - ✅ **NDJSON / JSON Lines** streaming — `read_lines` / `write_lines`, bounded memory *(v1.6.0)*.

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -115,7 +115,7 @@ int main() {
 | `qbuem::parse_reuse(doc, json)` | Same as `parse()` but documents intent to reuse the doc in a hot loop (tape memory is reused, not reallocated). |
 | `qbuem::parse_strict(doc, json)` | RFC 8259 strict mode. Throws on trailing commas, leading zeros, lone surrogates. |
 | `qbuem::read<T>(json)` | Parse JSON and deserialize into type `T`. Uses DOM engine + type mapping. |
-| `qbuem::fuse<T>(json)` | Nexus Fusion: zero-tape direct struct mapping. Fastest path. Requires `QBUEM_JSON_FIELDS`. |
+| `qbuem::fuse<T>(json)` | Nexus Fusion: zero-tape direct struct mapping. Fastest path. `QBUEM_JSON_FIELDS` for peak (compile-time switch) dispatch, or a plain aggregate macro-free on GCC/Clang. |
 
 **Important:** `Document` must outlive all `Value` objects derived from it. Values are 16-byte handles pointing into the document's tape.
 
@@ -220,7 +220,7 @@ auto title = root.at("/store/book/1/title"_jptr).as<std::string>();
 
 ## Struct Mapping — Macro-Free Reflection or QBUEM_JSON_FIELDS Macro
 
-**Macro-free (v1.14.0+, GCC/Clang):** a plain aggregate struct (public members, no user-declared constructors, no base classes) serializes/deserializes with NO registration — qbuem::write/read and cbor::encode/decode reflect the fields and recover their names automatically. Built for backend DTOs. Works for any linkage (incl. anonymous-namespace/local types) and non-constexpr members (std::map); default-constructible, <= 32 fields. A QBUEM_JSON_FIELDS / from_qbuem_json registration ALWAYS wins (purely additive). The zero-tape fuse<T> path still needs the macro.
+**Macro-free (v1.14.0+, GCC/Clang):** a plain aggregate struct (public members, no user-declared constructors, no base classes) serializes/deserializes with NO registration — qbuem::write/read and cbor::encode/decode reflect the fields and recover their names automatically. Built for backend DTOs. Works for any linkage (incl. anonymous-namespace/local types) and non-constexpr members (std::map); default-constructible, <= 32 fields. A QBUEM_JSON_FIELDS / from_qbuem_json registration ALWAYS wins (purely additive). The zero-tape fuse<T> path also works macro-free for aggregates — including generic (template) and nested ones — on GCC/Clang; its key→field routing is a reflected hash-ladder (vs the macro's compile-time switch), so for very wide hot-path structs the macro stays the peak-dispatch option (~1.5x on a realistic DTO).
 
 The `QBUEM_JSON_FIELDS` macro (for renames, skip, non-aggregates, >32 fields, or fuse) must be placed **outside** the struct, at namespace scope. It generates free functions for ADL-based serialization/deserialization.
 

--- a/docs/theory/nexus-fusion.md
+++ b/docs/theory/nexus-fusion.md
@@ -164,3 +164,25 @@ The macro must sit at **namespace scope** (not inside the struct) — it defines
 free functions, and placing it inside the struct breaks lookup. It supports up to 32
 fields; beyond that, write the ADL hooks (`from_qbuem_json` / `nexus_pulse` /
 `qbuem_json_append_fw`) by hand — same performance, no limit.
+
+## Macro-free fuse (no registration)
+
+On GCC/Clang you don't even need the macro. A **plain aggregate** — public members, no
+user-declared constructors, no base classes — fuses straight from reflected field names.
+Each template instantiation reflects on its own and nested aggregates recurse, so generic
+DTOs work with **no per-type registration**:
+
+```cpp
+template <class T>
+struct Envelope { T payload; uint64_t seq; std::string trace_id; };  // no macro
+
+auto e = qbuem::fuse<Envelope<Order>>(bytes);   // reflects Envelope<Order> automatically
+```
+
+The only difference from the macro is the **dispatch**: the macro emits a compile-time
+`switch` over field-name hashes (`O(1)`), while the macro-free path compares the scanned
+key's hash against each reflected field name (`O(fields)`). For small/medium structs that
+is near-parity; for **very wide hot-path structs** the macro stays the peak option
+(≈1.5× on a realistic DTO, growing with field count). A `QBUEM_JSON_FIELDS` /
+`QBUEM_JSON_FIELDS_TPL` registration, when present, always wins. Full rules:
+[Macro-Free Mapping](/guide/mapping#macro-free-mapping-aggregate-reflection).


### PR DESCRIPTION
Follow-up to #163. Several doc surfaces still said `fuse<T>` required `QBUEM_JSON_FIELDS`, or that macro-free reflection was JSON+CBOR only. Corrected across:

- **theory/nexus-fusion.md** — new *Macro-free fuse* section (generic/nested example + switch-vs-ladder tradeoff).
- **guide/parsing.md** — fuse section: macro **or** macro-free aggregate (GCC/Clang) + perf caveat + link.
- **guide/vision.md** — macro-free bullet now lists fuse (+ generic/nested).
- **config.mts** — FAQ "What is Nexus Fusion" dropped *Requires QBUEM_JSON_FIELDS*; featureList covers fuse.
- **public/llms-full.txt** — fuse row + the *fuse still needs the macro* line corrected for AI crawlers.
- **CHANGELOG.md** — `[Unreleased]` Added entry.

(mapping.md was already updated in #163.) `vitepress build` clean, no dead links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)